### PR TITLE
Submit processes with 'type(process).run_until_complete' 

### DIFF
--- a/plum/engine/parallel.py
+++ b/plum/engine/parallel.py
@@ -59,7 +59,7 @@ class MultithreadedEngine(execution_engine.ExecutionEngine, ProcessMonitorListen
 
     @override
     def run(self, process):
-        f = self._executor.submit(Process.run_until_complete, process)
+        f = self._executor.submit(type(process).run_until_complete, process)
         self._processes[process.pid] = f
         return self.Future(process, f)
 

--- a/plum/engine/serial.py
+++ b/plum/engine/serial.py
@@ -127,7 +127,7 @@ class SerialEngine(ExecutionEngine):
         if not isinstance(process, Process):
             raise TypeError("process must be of type Process")
 
-        return SerialEngine.Future(Process.run_until_complete, process)
+        return SerialEngine.Future(type(process).run_until_complete, process)
 
     def run_and_block(self, process_class, inputs):
         """
@@ -154,6 +154,3 @@ class SerialEngine(ExecutionEngine):
 
     def stop(self, pid):
         pass
-
-
-


### PR DESCRIPTION
This allows changing the behavior of run_until_complete in Process subclasses. Otherwise it is always the Process implementation that is called.