### PR TITLE
Validate `port_values` is type `Mapping` in `PortNamespace.validate`

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -585,17 +585,23 @@ class PortNamespace(collections.MutableMapping, Port):
 
         :param port_values: an arbitrarily nested dictionary of parsed port values
         :type port_values: dict
-        :param my_breadcrumbs: a tuple of the path to having reached this point in validation
-        :type my_breadcrumbs: typing.Tuple[str]
+        :param breadcrumbs: a tuple of the path to having reached this point in validation
+        :type breadcrumbs: typing.Tuple[str]
         :return: None or tuple containing 0: error string 1: tuple of breadcrumb strings to where the validation failed
         :rtype: typing.Optional[ValidationError]
         """
-        my_breadcrumbs = breadcrumbs + (self.name,)
+        breadcrumbs_local = breadcrumbs + (self.name,)
 
-        if port_values is None:
+        print('port-values', type(port_values), port_values)
+
+        if not port_values:
             port_values = {}
-        else:
-            port_values = dict(port_values)
+
+        if not isinstance(port_values, collections.Mapping):
+            message = 'specified value is of type {} which is not sub class of `Mapping`'.format(type(port_values))
+            return PortValidationError(message, breadcrumbs_to_port(breadcrumbs_local))
+
+        port_values = dict(port_values)
 
         # Validate the validator first as it most likely will rely on the port values
         if self.validator is not None:
@@ -603,7 +609,7 @@ class PortNamespace(collections.MutableMapping, Port):
             if message is not None:
                 assert isinstance(message, str), \
                     "Validator returned something other than None or str: '{}'".format(type(message))
-                return PortValidationError(message, breadcrumbs_to_port(my_breadcrumbs))
+                return PortValidationError(message, breadcrumbs_to_port(breadcrumbs_local))
 
         # If the namespace is not required and there are no port_values specified, consider it valid
         if not port_values and not self.required:
@@ -611,7 +617,7 @@ class PortNamespace(collections.MutableMapping, Port):
 
         # In all other cases, validate all input ports explicitly specified in this port namespace
         else:
-            validation_error = self.validate_ports(port_values, my_breadcrumbs)
+            validation_error = self.validate_ports(port_values, breadcrumbs_local)
             if validation_error:
                 return validation_error
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     install_requires=[
         'frozendict',
         'tornado>=4.1, <5.0',
+        'pika==1.0.0b1',
         'kiwipy[rmq]>=0.4.2, <0.5.0',
         'enum34; python_version<"3.4"',
         'backports.tempfile; python_version<"3.2"',
@@ -47,7 +48,7 @@ setup(
     extras_require={
         'dev': [
             'pip',
-            'pytest',
+            'pytest>4',
             'ipython',
             'twine',
             'pytest-cov',

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -77,19 +77,19 @@ class TestPortNamespace(TestCase):
         as they and all intermediate nested PortNamespaces exist
         """
         with self.assertRaises(TypeError):
-            port_namespace = self.port_namespace.get_port()
+            self.port_namespace.get_port()
 
         with self.assertRaises(ValueError):
-            port_namespace = self.port_namespace.get_port(5)
+            self.port_namespace.get_port(5)
 
         with self.assertRaises(ValueError):
-            port_namespace = self.port_namespace.get_port('sub')
+            self.port_namespace.get_port('sub')
 
         port_namespace_sub = self.port_namespace.create_port_namespace('sub')
         self.assertEqual(self.port_namespace.get_port('sub'), port_namespace_sub)
 
         with self.assertRaises(ValueError):
-            port_namespace = self.port_namespace.get_port('sub.name.space')
+            self.port_namespace.get_port('sub.name.space')
 
         port_namespace_sub = self.port_namespace.create_port_namespace('sub.name.space')
         self.assertEqual(self.port_namespace.get_port('sub.name.space'), port_namespace_sub)
@@ -104,10 +104,10 @@ class TestPortNamespace(TestCase):
         Test the create_port_namespace function of the PortNamespace class
         """
         with self.assertRaises(TypeError):
-            port_namespace = self.port_namespace.create_port_namespace()
+            self.port_namespace.create_port_namespace()
 
         with self.assertRaises(ValueError):
-            port_namespace = self.port_namespace.create_port_namespace(5)
+            self.port_namespace.create_port_namespace(5)
 
         port_namespace_sub = self.port_namespace.create_port_namespace('sub')
         port_namespace_sub = self.port_namespace.create_port_namespace('some.nested.sub.space')
@@ -141,15 +141,22 @@ class TestPortNamespace(TestCase):
 
     def test_port_namespace_validate(self):
         """Check that validating of sub namespaces works correctly"""
-        port_namespace_sub = self.port_namespace.create_port_namespace('sub.name.space')
+        port_namespace_sub = self.port_namespace.create_port_namespace('sub.space')
         port_namespace_sub.valid_type = int
-        validation_error = self.port_namespace.validate({'sub': {'name': {'space': {'my_out': 5}}}})
+
+        # Check that passing a non mapping type raises
+        validation_error = self.port_namespace.validate(5)
+        self.assertIsNotNone(validation_error)
+
+        # Valid input
+        validation_error = self.port_namespace.validate({'sub': {'space': {'output': 5}}})
         self.assertIsNone(validation_error)
-        validation_error = self.port_namespace.validate({'sub': {'name': {'space': {'my_out': '5'}}}})
+
+        # Invalid input
+        validation_error = self.port_namespace.validate({'sub': {'space': {'output': '5'}}})
         self.assertIsNotNone(validation_error)
 
         # Check the breadcrumbs are correct
         self.assertEqual(
             validation_error.port,
-            self.port_namespace.NAMESPACE_SEPARATOR.join((self.BASE_PORT_NAMESPACE_NAME, 'sub', 'name', 'space',
-                                                          'my_out')))
+            self.port_namespace.NAMESPACE_SEPARATOR.join((self.BASE_PORT_NAMESPACE_NAME, 'sub', 'space', 'output')))


### PR DESCRIPTION
Fixes #88 

Any value passed for a namespace has to be a `Mapping` type, anything
else does not make sense. This should be checked before casting it to a
dictionary which will raise if the value is not a mapping type.