### PR TITLE
Rename `Process._spec_type` to `Process._spec_class`

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -592,8 +592,6 @@ class PortNamespace(collections.MutableMapping, Port):
         """
         breadcrumbs_local = breadcrumbs + (self.name,)
 
-        print('port-values', type(port_values), port_values)
-
         if not port_values:
             port_values = {}
 

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -131,7 +131,7 @@ class Process(StateMachine, persistence.Savable):
     """
 
     # Static class stuff ######################
-    _spec_type = ProcessSpec
+    _spec_class = ProcessSpec
     # Default placeholders, will be populated in init()
     _stepping = False
     _pausing = None  # type: futures.Future
@@ -179,7 +179,7 @@ class Process(StateMachine, persistence.Savable):
         try:
             return cls.__getattribute__(cls, '_spec')
         except AttributeError:
-            cls._spec = cls._spec_type()
+            cls._spec = cls._spec_class()
             cls.__called = False
             cls.define(cls._spec)
             assert cls.__called, \

--- a/plumpy/workchains.py
+++ b/plumpy/workchains.py
@@ -87,7 +87,7 @@ class WorkChain(mixins.ContextMixin, processes.Process):
     A WorkChain is a series of instructions carried out with the ability to save
     state in between.
     """
-    _spec_type = WorkChainSpec
+    _spec_class = WorkChainSpec
     _STEPPER_STATE = 'stepper_state'
     _CONTEXT = 'CONTEXT'
 


### PR DESCRIPTION
Fixes #90 