### PR TITLE
Make the default value for `PortNamespace` an empty dictionary

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -1163,6 +1163,8 @@ class Process(StateMachine, persistence.Savable):
                     port_value = port.default
                 elif port.required:
                     raise ValueError('Value not supplied for required inputs port {}'.format(name))
+                elif isinstance(port, ports.PortNamespace):
+                    port_value = {}
                 else:
                     continue
             else:

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -126,6 +126,21 @@ class TestProcess(utils.AsyncTestCase):
             self.assertIn('input', p.inputs)
             self.assertEqual(p.inputs['input'], def_val)
 
+    def test_nested_namespace_defaults(self):
+        """Process with a default in a nested namespace should be created, even if top level namespace not supplied."""
+
+        class SomeProcess(Process):
+
+            @classmethod
+            def define(cls, spec):
+                super(SomeProcess, cls).define(spec)
+                spec.input_namespace('namespace', required=False)
+                spec.input('namespace.sub', default=True)
+
+        process = SomeProcess()
+        self.assertIn('sub', process.inputs.namespace)
+        self.assertEqual(process.inputs.namespace.sub, True)
+
     def test_execute(self):
         proc = test_utils.DummyProcessWithOutput()
         proc.execute()


### PR DESCRIPTION
Fixes #92 

A `Port` with a default value, nested in a non-required namespace, was
not being generated when creating an instance of the `Process` if no
explicit value was being passed for the parent namespace. The solution
is to simply create an empty dictionary for all port namespaces, even if
no explicit value is passed.