### PR TITLE
Fix the version requirements for the `pika` and `kiwipy` dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from __future__ import absolute_import
 from setuptools import setup
 
@@ -30,17 +29,11 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords='workflow multithreaded rabbitmq',
-    # Abstract dependencies.  Concrete versions are listed in
-    # requirements.txt
-    # See https://caremad.io/2013/07/setup-vs-requirement/ for an explanation
-    # of the difference and
-    # http://blog.miguelgrinberg.com/post/the-package-dependency-blues
-    # for a useful dicussion
     install_requires=[
         'frozendict',
         'tornado>=4.1, <5.0',
-        'pika==1.0.0b1',
-        'kiwipy[rmq]>=0.4.2, <0.5.0',
+        'pika>=1.0.0b2',
+        'kiwipy[rmq]>=0.5.0, <0.6.0',
         'enum34; python_version<"3.4"',
         'backports.tempfile; python_version<"3.2"',
         'six',


### PR DESCRIPTION
Fixes #95 

The recently released `pika==1.0.0b2` is the last expected beta and no
more breaking changes should be introduced in the final release. The
`topika` and `kiwipy` libraries have already been updated to be
compatible with this version in `v0.2.0` and `v0.5.0`, respectively.
Since we only depend directly on `kiwipy` and `pika` we update their
version requirements.