### PR TITLE
Fix call of `Portnamespace.validator`

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -603,7 +603,7 @@ class PortNamespace(collections.MutableMapping, Port):
 
         # Validate the validator first as it most likely will rely on the port values
         if self.validator is not None:
-            message = self.validator(self, port_values)
+            message = self.validator(port_values)
             if message is not None:
                 assert isinstance(message, str), \
                     "Validator returned something other than None or str: '{}'".format(type(message))

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -61,6 +61,18 @@ class TestPortNamespace(TestCase):
         with self.assertRaises(KeyError):
             self.port_namespace['non_existent']
 
+    def test_port_namespace_validation(self):
+        """Test validate method of a `PortNamespace`."""
+        def validator(port_values):
+            if port_values['integer'] < 0:
+                return 'Only positive integers allowed'
+
+        self.port_namespace.validator = validator
+        self.port_namespace.valid_type = int
+
+        self.assertIsNone(self.port_namespace.validate({'integer': 5}))
+        self.assertIsNotNone(self.port_namespace.validate({'integer': -5}))
+
     def test_port_namespace_dynamic(self):
         """
         Setting a valid type for a PortNamespace should automatically make it dynamic

--- a/test/test_process_spec.py
+++ b/test/test_process_spec.py
@@ -77,7 +77,7 @@ class TestProcessSpec(TestCase):
         Test the global spec validator functionality.
         """
 
-        def is_valid(_spec, inputs):
+        def is_valid(inputs):
             if not ('a' in inputs) ^ ('b' in inputs):
                 return 'Must have a OR b in inputs'
             return


### PR DESCRIPTION
Fixes #103 

The `validator` holds a reference to an unbound function that should be
called with the values passed to the port to validate them. The `validate`
was incorrectly passing `self` as the first argument, in addition to the
port values.