### PR TITLE
Enable testing for python 3.7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,24 @@
+dist: xenial
+sudo: required
+
 language: python
 cache: pip
 
-services:
-  - rabbitmq
+before_install:
+  - sudo apt install rabbitmq-server
+addons:
+  apt:
+    update: true
 
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 
 install:
-  - pip install .[rmq,dev]
+  - pip install .[dev]
 
 script:
   - py.test

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='workflow multithreaded rabbitmq',
     install_requires=[


### PR DESCRIPTION
Fixes #101 

The only problem is that python 3.7 still requires xenial on Travis
which doesn't come with `rabbitmq` as a service, so we have to install
manually through `sudo apt`.