### PR TITLE
Add tests for InMemoryPersister and Bundle class

### DIFF
--- a/plumpy/persistence.py
+++ b/plumpy/persistence.py
@@ -26,12 +26,6 @@ PersistedCheckpoint = collections.namedtuple('PersistedCheckpoint', ['pid', 'tag
 
 class Bundle(dict):
 
-    @classmethod
-    def from_dict(cls, *args, **kwargs):
-        self = Bundle.__new__(*args, **kwargs)
-        super(Bundle, self).from_dict(*args, **kwargs)
-        return self
-
     def __init__(self, savable, save_context=None):
         """
         Create a bundle from a savable.  Optionally keep information about the
@@ -306,8 +300,7 @@ class PicklePersister(Persister):
             self.delete_checkpoint(checkpoint.pid, checkpoint.tag)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class InMemoryPersister(object):
+class InMemoryPersister(Persister):
     """ Mainly to be used in testing/debugging """
 
     def __init__(self, loader=None):
@@ -329,8 +322,11 @@ class InMemoryPersister(object):
 
     def get_process_checkpoints(self, pid):
         cps = []
-        for tag, bundle in self._checkpoints[pid]:
-            cps.append(PersistedCheckpoint(tag, bundle))
+        try:
+            for tag, bundle in self._checkpoints[pid].items():
+                cps.append(PersistedCheckpoint(pid, tag))
+        except KeyError:
+            pass
         return cps
 
     def delete_checkpoint(self, pid, tag=None):

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'dev': [
             'pip',
             'pytest>4',
-            'ipython',
+            'ipython>=4.0,<6.0',
             'twine',
             'pytest-cov',
             'pre-commit',

--- a/test/persistence/test_inmemory.py
+++ b/test/persistence/test_inmemory.py
@@ -1,0 +1,153 @@
+from __future__ import absolute_import
+
+import plumpy
+from plumpy.test_utils import ProcessWithCheckpoint
+from test.utils import TestCaseWithLoop
+
+
+class TestInMemoryPersister(TestCaseWithLoop):
+
+    def test_save_load_roundtrip(self):
+        """
+        Test the plumpy.PicklePersister by taking a dummpy process, saving a checkpoint
+        and recreating it from the same checkpoint
+        """
+        process = ProcessWithCheckpoint()
+
+        persister = plumpy.InMemoryPersister()
+        persister.save_checkpoint(process)
+
+        bundle = persister.load_checkpoint(process.pid)
+        load_context = plumpy.LoadSaveContext(loop=self.loop)
+        recreated = bundle.unbundle(load_context)
+
+    def test_get_checkpoints_without_tags(self):
+        """
+        """
+        process_a = ProcessWithCheckpoint()
+        process_b = ProcessWithCheckpoint()
+
+        checkpoint_a = plumpy.PersistedCheckpoint(process_a.pid, None)
+        checkpoint_b = plumpy.PersistedCheckpoint(process_b.pid, None)
+
+        checkpoints = [checkpoint_a, checkpoint_b]
+
+        persister = plumpy.InMemoryPersister()
+        persister.save_checkpoint(process_a)
+        persister.save_checkpoint(process_b)
+
+        retrieved_checkpoints = persister.get_checkpoints()
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+    def test_get_checkpoints_with_tags(self):
+        """
+        """
+        process_a = ProcessWithCheckpoint()
+        process_b = ProcessWithCheckpoint()
+        tag_a = 'tag_a'
+        tag_b = 'tag_b'
+
+        checkpoint_a = plumpy.PersistedCheckpoint(process_a.pid, tag_a)
+        checkpoint_b = plumpy.PersistedCheckpoint(process_b.pid, tag_b)
+
+        # import pdb; pdb.set_trace()
+        checkpoints = [checkpoint_a, checkpoint_b]
+
+        persister = plumpy.InMemoryPersister()
+        persister.save_checkpoint(process_a, tag=tag_a)
+        persister.save_checkpoint(process_b, tag=tag_b)
+
+        retrieved_checkpoints = persister.get_checkpoints()
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+    def test_get_process_checkpoints(self):
+        """
+        """
+        process_a = ProcessWithCheckpoint()
+        process_b = ProcessWithCheckpoint()
+
+        checkpoint_a1 = plumpy.PersistedCheckpoint(process_a.pid, '1')
+        checkpoint_a2 = plumpy.PersistedCheckpoint(process_a.pid, '2')
+        checkpoint_b1 = plumpy.PersistedCheckpoint(process_b.pid, '1')
+        checkpoint_b2 = plumpy.PersistedCheckpoint(process_b.pid, '2')
+
+        checkpoints = [checkpoint_a1, checkpoint_a2]
+
+        persister = plumpy.InMemoryPersister()
+        persister.save_checkpoint(process_a, tag='1')
+        persister.save_checkpoint(process_a, tag='2')
+        persister.save_checkpoint(process_b, tag='1')
+        persister.save_checkpoint(process_b, tag='2')
+
+        retrieved_checkpoints = persister.get_process_checkpoints(process_a.pid)
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+    def test_delete_process_checkpoints(self):
+        """
+        """
+        process_a = ProcessWithCheckpoint()
+        process_b = ProcessWithCheckpoint()
+
+        checkpoint_a1 = plumpy.PersistedCheckpoint(process_a.pid, '1')
+        checkpoint_a2 = plumpy.PersistedCheckpoint(process_a.pid, '2')
+        checkpoint_b1 = plumpy.PersistedCheckpoint(process_b.pid, '1')
+        checkpoint_b2 = plumpy.PersistedCheckpoint(process_b.pid, '2')
+
+        persister = plumpy.InMemoryPersister()
+        persister.save_checkpoint(process_a, tag='1')
+        persister.save_checkpoint(process_a, tag='2')
+        persister.save_checkpoint(process_b, tag='1')
+        persister.save_checkpoint(process_b, tag='2')
+
+        checkpoints = [checkpoint_a1, checkpoint_a2]
+        retrieved_checkpoints = persister.get_process_checkpoints(process_a.pid)
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+        persister.delete_process_checkpoints(process_a.pid)
+
+        checkpoints = []
+        retrieved_checkpoints = persister.get_process_checkpoints(process_a.pid)
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+    def test_delete_checkpoint(self):
+        """
+        """
+        process_a = ProcessWithCheckpoint()
+        process_b = ProcessWithCheckpoint()
+
+        checkpoint_a1 = plumpy.PersistedCheckpoint(process_a.pid, '1')
+        checkpoint_a2 = plumpy.PersistedCheckpoint(process_a.pid, '2')
+        checkpoint_b1 = plumpy.PersistedCheckpoint(process_b.pid, '1')
+        checkpoint_b2 = plumpy.PersistedCheckpoint(process_b.pid, '2')
+
+        checkpoints = [checkpoint_a1, checkpoint_a2, checkpoint_b1]
+
+        persister = plumpy.InMemoryPersister()
+        persister.save_checkpoint(process_a, tag='1')
+        persister.save_checkpoint(process_a, tag='2')
+        persister.save_checkpoint(process_b, tag='1')
+        persister.save_checkpoint(process_b, tag='2')
+
+        checkpoints = [checkpoint_a1, checkpoint_a2, checkpoint_b1, checkpoint_b2]
+        retrieved_checkpoints = persister.get_checkpoints()
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+        persister.delete_checkpoint(process_a.pid, tag='2')
+
+        checkpoints = [checkpoint_a1, checkpoint_b1, checkpoint_b2]
+        retrieved_checkpoints = persister.get_checkpoints()
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))
+
+        persister.delete_checkpoint(process_b.pid, tag='1')
+
+        checkpoints = [checkpoint_a1, checkpoint_b2]
+        retrieved_checkpoints = persister.get_checkpoints()
+
+        self.assertSetEqual(set(retrieved_checkpoints), set(checkpoints))

--- a/test/rmq/test_process_comms.py
+++ b/test/rmq/test_process_comms.py
@@ -194,6 +194,7 @@ class TestRemoteProcessThreadController(testing.AsyncTestCase):
 
         # Check the outcome
         self.assertTrue(result)
+        # Occasionally fail
         self.assertEqual(proc.state, plumpy.ProcessState.KILLED)
 
     @testing.gen_test

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -1,6 +1,7 @@
 import plumpy
 from plumpy import test_utils
 import unittest
+import yaml
 
 from . import utils
 
@@ -9,10 +10,14 @@ class SaveEmpty(plumpy.Savable):
     pass
 
 
-@plumpy.auto_persist('test')
+@plumpy.auto_persist('test', 'test_method')
 class Save1(plumpy.Savable):
     def __init__(self):
         self.test = 'sup yp'
+        self.test_method = self.m
+
+    def m():
+        pass
 
 
 @plumpy.auto_persist('test')
@@ -27,9 +32,11 @@ class TestSavable(unittest.TestCase):
 
     def test_auto_persist(self):
         self._save_round_trip(Save1())
+        self._save_round_trip_with_loader(Save1())
 
     def test_auto_persist_savable(self):
         self._save_round_trip(Save())
+        self._save_round_trip_with_loader(Save())
 
     def _save_round_trip(self, savable):
         """
@@ -46,8 +53,27 @@ class TestSavable(unittest.TestCase):
         saved_state2 = loaded.save()
         self.assertDictEqual(saved_state1, saved_state2)
 
+    def _save_round_trip_with_loader(self, savable):
+        """
+        Do a round trip:
+        1) Save `savables` state
+        2) Recreate from the saved state
+        3) Save the state of the recreated `Savable`
+        4) Compare the two saved states (they should match)
+
+        :type savable: :class:`plumpy.Savable`
+        """
+        object_loader = plumpy.get_object_loader()
+        saved_state1 = savable.save(plumpy.LoadSaveContext(object_loader))
+        loaded = savable.recreate_from(saved_state1)
+        saved_state2 = loaded.save(plumpy.LoadSaveContext(object_loader))
+        saved_state3 = loaded.save()
+        self.assertDictEqual(saved_state1, saved_state2)
+        self.assertNotEqual(saved_state1, saved_state3)
+
 
 class TestBundle(utils.TestCaseWithLoop):
+
     def test_bundle_load_context(self):
         """ Check that the loop from the load context is used """
         proc = test_utils.DummyProcess(loop=self.loop)
@@ -56,3 +82,11 @@ class TestBundle(utils.TestCaseWithLoop):
         loop2 = plumpy.new_event_loop()
         proc2 = bundle.unbundle(plumpy.LoadSaveContext(loop=loop2))
         self.assertIs(loop2, proc2.loop())
+
+    def test_bundle_yaml(self):
+        bundle = plumpy.Bundle(Save1())
+        represent = yaml.dump({'bundle': bundle})
+
+        bundle_loaded = yaml.load(represent, Loader=yaml.Loader)['bundle']
+        self.assertIsInstance(bundle_loaded, plumpy.Bundle)
+        self.assertDictEqual(bundle_loaded, Save1().save())


### PR DESCRIPTION
Add tests for InMemoryPersister and Bundle, increase test coverage of persistence.py from 85% to 93%
fix InMemoryPersister `get_process_checkpoints()` dict non-iterable Error and rewrite Bundle `from_dict()` method.
