### PR TITLE
fix for issue 109

### DIFF
--- a/test/rmq/test_process_comms.py
+++ b/test/rmq/test_process_comms.py
@@ -175,7 +175,7 @@ class TestRemoteProcessThreadController(testing.AsyncTestCase):
         self.assertTrue(proc.pause())
 
         # Send a play message
-        play_future = self.process_controller.pause_process(proc.pid)
+        play_future = self.process_controller.play_process(proc.pid)
         # Allow the process to respond to the request
         result = yield play_future
 
@@ -187,8 +187,8 @@ class TestRemoteProcessThreadController(testing.AsyncTestCase):
     def test_kill(self):
         proc = test_utils.WaitForSignalProcess(communicator=self.communicator)
 
-        # Send a play message
-        kill_future = self.process_controller.kill_process(proc.pid)
+        # Send a kill message
+        kill_future = yield self.process_controller.kill_process(proc.pid)
         # Allow the process to respond to the request
         result = yield kill_future
 


### PR DESCRIPTION
Using `yield` to wait `kill_process` to finish pass the test(no test failed after 1000 repeat). Is this the right way to fix the issue https://github.com/aiidateam/plumpy/issues/109?

However, I think the instance of class `RemoteProcessThreadController` should not run as corountine in these unittest. 
Thus the testset class `TestRemoteProcessThreadController` is no need to be the subclass of `AsyncTestCase`?