### PR TITLE
Fix the implementation of `include` in `PortNamespace.absorb`

### DIFF
--- a/plumpy/process_spec.py
+++ b/plumpy/process_spec.py
@@ -171,7 +171,7 @@ class ProcessSpec(object):
         """
         return name in self.outputs
 
-    def expose_inputs(self, process_class, namespace=None, exclude=(), include=None, namespace_options={}):
+    def expose_inputs(self, process_class, namespace=None, exclude=None, include=None, namespace_options={}):
         """
         This method allows one to automatically add the inputs from another Process to this ProcessSpec.
         The optional namespace argument can be used to group the exposed inputs in a separated PortNamespace.
@@ -195,7 +195,7 @@ class ProcessSpec(object):
             namespace_options=namespace_options,
         )
 
-    def expose_outputs(self, process_class, namespace=None, exclude=(), include=None, namespace_options={}):
+    def expose_outputs(self, process_class, namespace=None, exclude=None, include=None, namespace_options={}):
         """
         This method allows one to automatically add the ouputs from another Process to this ProcessSpec.
         The optional namespace argument can be used to group the exposed outputs in a separated PortNamespace.

--- a/test/test_expose.py
+++ b/test/test_expose.py
@@ -1,14 +1,30 @@
 from __future__ import absolute_import
-from . import utils
+
 from plumpy.ports import PortNamespace
+from plumpy.processes import Process
 from plumpy.process_spec import ProcessSpec
 from plumpy.test_utils import NewLoopProcess
+from . import utils
 
 
 class TestExposeProcess(utils.TestCaseWithLoop):
 
     def setUp(self):
         super(TestExposeProcess, self).setUp()
+
+        def validator_function(input):
+            pass
+
+        class BaseNamespaceProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(BaseNamespaceProcess, cls).define(spec)
+                spec.input('top')
+                spec.input('namespace.sub_one')
+                spec.input('namespace.sub_two')
+                spec.inputs['namespace'].valid_type = (int, float)
+                spec.inputs['namespace'].validator = validator_function
 
         class BaseProcess(NewLoopProcess):
 
@@ -31,13 +47,40 @@ class TestExposeProcess(utils.TestCaseWithLoop):
                 spec.inputs.dynamic = True
                 spec.inputs.valid_type = int
 
+        self.BaseNamespaceProcess = BaseNamespaceProcess
         self.BaseProcess = BaseProcess
         self.ExposeProcess = ExposeProcess
 
+    def check_ports(self, process, namespace, expected_port_names):
+        """Check the port namespace of a given process inputs spec for existence of set of expected port names."""
+        port_namespace = process.spec().inputs
+
+        if namespace is not None:
+            port_namespace = process.spec().inputs.get_port(namespace)
+
+        self.assertEqual(set(port_namespace.keys()), set(expected_port_names))
+
+    def check_namespace_properties(self, process_left, namespace_left, process_right, namespace_right):
+        """Check that all properties, with exception of ports, of two port namespaces are equal."""
+        if not issubclass(process_left, Process) or not issubclass(process_right, Process):
+            raise TypeError('`process_left` and `process_right` should be processes')
+
+        port_namespace_left = process_left.spec().inputs.get_port(namespace_left)
+        port_namespace_right = process_right.spec().inputs.get_port(namespace_right)
+
+        # Pop the ports in stored in the `_ports` attribute
+        port_namespace_left.__dict__.pop('_ports', None)
+        port_namespace_right.__dict__.pop('_ports', None)
+
+        # The `_value_spec` is a nested dictionary so should be compared explicitly separately
+        value_spec_left = port_namespace_left._value_spec
+        value_spec_right = port_namespace_right._value_spec
+
+        self.assertEqual(port_namespace_left.__dict__, port_namespace_right.__dict__)
+        self.assertEqual(value_spec_left.__dict__, value_spec_right.__dict__)
+
     def test_expose_nested_namespace(self):
-        """
-        Test that expose_inputs can create nested namespaces while maintaining own ports
-        """
+        """Test that expose_inputs can create nested namespaces while maintaining own ports."""
         inputs = self.ExposeProcess.spec().inputs
 
         # Verify that the nested namespaces are present
@@ -57,9 +100,7 @@ class TestExposeProcess(utils.TestCaseWithLoop):
         self.assertEqual(inputs['d'].default, 2)
 
     def test_expose_ports(self):
-        """
-        Test that the exposed ports are present and properly deepcopied
-        """
+        """Test that the exposed ports are present and properly deepcopied."""
         exposed_inputs = self.ExposeProcess.spec().inputs.get_port('base.name.space')
 
         self.assertEqual(len(exposed_inputs), 2)
@@ -74,9 +115,7 @@ class TestExposeProcess(utils.TestCaseWithLoop):
         self.assertEqual(exposed_inputs['a'].default, 'a')
 
     def test_expose_attributes(self):
-        """
-        Test that the attributes of the exposed PortNamespace are maintained and properly deepcopied
-        """
+        """Test that the attributes of the exposed PortNamespace are maintained and properly deepcopied."""
         inputs = self.ExposeProcess.spec().inputs
         exposed_inputs = self.ExposeProcess.spec().inputs.get_port('base.name.space')
 
@@ -92,9 +131,7 @@ class TestExposeProcess(utils.TestCaseWithLoop):
         self.assertEqual(inputs.valid_type, int)
 
     def test_expose_exclude(self):
-        """
-        Test that the exclude argument of exposed_inputs works correctly and excludes ports from being absorbed
-        """
+        """Test that the exclude argument of exposed_inputs works correctly and excludes ports from being absorbed."""
         BaseProcess = self.BaseProcess
 
         class ExcludeProcess(NewLoopProcess):
@@ -112,9 +149,7 @@ class TestExposeProcess(utils.TestCaseWithLoop):
         self.assertTrue('a' not in inputs)
 
     def test_expose_include(self):
-        """
-        Test that the include argument of exposed_inputs works correctly and includes only specified ports
-        """
+        """Test that the include argument of exposed_inputs works correctly and includes only specified ports."""
         BaseProcess = self.BaseProcess
 
         class ExcludeProcess(NewLoopProcess):
@@ -132,9 +167,7 @@ class TestExposeProcess(utils.TestCaseWithLoop):
         self.assertTrue('a' not in inputs)
 
     def test_expose_exclude_include_mutually_exclusive(self):
-        """
-        Test that passing both exclude and include raises
-        """
+        """Test that passing both exclude and include raises."""
         BaseProcess = self.BaseProcess
 
         class ExcludeProcess(NewLoopProcess):
@@ -148,62 +181,6 @@ class TestExposeProcess(utils.TestCaseWithLoop):
 
         with self.assertRaises(ValueError):
             ExcludeProcess.spec()
-
-    def test_expose_nested_exclude(self):
-        """Test the exclude rules can be nested and are properly unwrapped."""
-        BaseProcess = self.BaseProcess
-
-        def test_validator(self):
-            pass
-
-        class BaseProcess(NewLoopProcess):
-
-            @classmethod
-            def define(cls, spec):
-                super(BaseProcess, cls).define(spec)
-                spec.input('a', valid_type=str, default='a')
-                spec.input('b', valid_type=str, default='b')
-                spec.inputs.dynamic = True
-                spec.inputs.valid_type = str
-                spec.inputs.help = 'Base Process'
-
-        class SubProcess(NewLoopProcess):
-
-            @classmethod
-            def define(cls, spec):
-                super(SubProcess, cls).define(spec)
-                spec.expose_inputs(BaseProcess, namespace='base')
-                spec.input('c', valid_type=str, default='c')
-                spec.input('d', valid_type=str, default='d')
-                spec.inputs.valid_type = int
-                spec.inputs.help = 'Sub Process'
-                spec.inputs.validator = test_validator
-
-        class ExcludeProcess(NewLoopProcess):
-
-            @classmethod
-            def define(cls, spec):
-                super(ExcludeProcess, cls).define(spec)
-                spec.expose_inputs(SubProcess, exclude=('base.a', 'c'))
-
-        inputs = ExcludeProcess.spec().inputs
-
-        # Check that port `base.b` is present but `base.a` is not, as it was excluded
-        self.assertTrue('a' not in inputs['base'])
-        self.assertTrue('b' in inputs['base'])
-        self.assertTrue('c' not in inputs)
-        self.assertTrue('d' in inputs)
-
-        # Properties of the exposed sub namespaces should have been preserved
-        self.assertEqual(inputs['base'].dynamic, True)
-        self.assertEqual(inputs['base'].valid_type, str)
-        self.assertEqual(inputs['base'].help, 'Base Process')
-
-        # Properties of the top level should match that of the `SubProcess` because it was not exposed in a namespace
-        self.assertEqual(inputs.dynamic, True)
-        self.assertEqual(inputs.valid_type, int)
-        self.assertEqual(inputs.help, 'Sub Process')
-        self.assertEqual(inputs.validator, test_validator)
 
     def test_expose_ports_top_level(self):
         """
@@ -371,3 +348,127 @@ class TestExposeProcess(utils.TestCaseWithLoop):
                 namespace_options={
                     'non_existent': None,
                 })
+
+    def test_expose_nested_include_top_level(self):
+        """Test the include rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', include=('top',))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['top'])
+
+    def test_expose_nested_include_namespace(self):
+        """Test the include rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', include=('namespace',))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['namespace'])
+        self.check_ports(ExposeProcess, 'base.namespace', ['sub_one', 'sub_two'])
+        self.check_namespace_properties(BaseNamespaceProcess, 'namespace', ExposeProcess, 'base.namespace')
+
+    def test_expose_nested_include_namespace_sub(self):
+        """Test the include rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', include=('namespace.sub_two',))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['namespace'])
+        self.check_ports(ExposeProcess, 'base.namespace', ['sub_two'])
+        self.check_namespace_properties(BaseNamespaceProcess, 'namespace', ExposeProcess, 'base.namespace')
+
+    def test_expose_nested_include_combination(self):
+        """Test the include rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', include=('namespace.sub_two', 'top'))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['namespace', 'top'])
+        self.check_ports(ExposeProcess, 'base.namespace', ['sub_two'])
+        self.check_namespace_properties(BaseNamespaceProcess, 'namespace', ExposeProcess, 'base.namespace')
+
+    def test_expose_nested_exclude_top_level(self):
+        """Test the exclude rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', exclude=('top',))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['namespace'])
+        self.check_ports(ExposeProcess, 'base.namespace', ['sub_one', 'sub_two'])
+        self.check_namespace_properties(BaseNamespaceProcess, 'namespace', ExposeProcess, 'base.namespace')
+
+    def test_expose_nested_exclude_namespace(self):
+        """Test the exclude rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', exclude=('namespace',))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['top'])
+
+    def test_expose_nested_exclude_namespace_sub(self):
+        """Test the exclude rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', exclude=('namespace.sub_two',))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['top', 'namespace'])
+        self.check_ports(ExposeProcess, 'base.namespace', ['sub_one'])
+        self.check_namespace_properties(BaseNamespaceProcess, 'namespace', ExposeProcess, 'base.namespace')
+
+    def test_expose_nested_exclude_combination(self):
+        """Test the exclude rules can be nested and are properly unwrapped."""
+        BaseNamespaceProcess = self.BaseNamespaceProcess
+
+        class ExposeProcess(NewLoopProcess):
+
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(BaseNamespaceProcess, namespace='base', exclude=('namespace.sub_two', 'top'))
+
+        self.check_ports(ExposeProcess, None, ['base'])
+        self.check_ports(ExposeProcess, 'base', ['namespace'])
+        self.check_ports(ExposeProcess, 'base.namespace', ['sub_one'])
+        self.check_namespace_properties(BaseNamespaceProcess, 'namespace', ExposeProcess, 'base.namespace')


### PR DESCRIPTION
Fixes #119 

Fix the implementation of `include` in `PortNamespace.absorb`

The recent introduction of support for nested namespaces in the
`exclude` and `include` rules of the `PortNamespace.absorb` method is
incorrect when `include` rules are specified. The exclude and include
rules need to be properly unwrapped to account for nesting, however,
this needs to happen at different moments. For exclude rules, namespaces
have to be done on the `leaf` level. As soon as the rule matches exactly
the port name that is considered it should be filtered.

With the include rules it works a little different. For rules
representing nested ports, all the namespaces along the way to the leaf
port *have* to be included as well.