### PR TITLE
Add the concept of a "lazy" `PortNamespace`

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -376,13 +376,15 @@ class PortNamespace(collections.MutableMapping, Port):
 
         :param name: the name of the namespace
         :param help: the help string
-        :param required: boolean, if True the validation will fail if no value is specified for this namespace
+        :param required: boolean, if `True` the validation will fail if no value is specified for this namespace
         :param validator: an optional validator for the namespace
         :param valid_type: optional tuple of valid types in the case of a dynamic namespace
         :param default: default value for the port
-        :param dynamic: boolean, if True, the namespace will accept values even when no explicit port is defined
-        :param populate_defaults: boolean, if False, the pre-processing step does not populate defaults, also not of any
-            nested ports, if no value was explicitly specified for this namespace.
+        :param dynamic: boolean, if `True`, the namespace will accept values even when no explicit port is defined
+        :param populate_defaults: boolean, when set to `False`, the populating of defaults for this namespace is skipped
+            entirely, including all nested namespaces, if no explicit value is passed for this port in the parent
+            namespace. As soon as a value is specified in the parent namespace for this port, even if it is empty, this
+            property is ignored and the population of defaults is always performed.
         """
         super(PortNamespace, self).__init__(
             name=name, help=help, required=required, validator=validator, valid_type=valid_type)


### PR DESCRIPTION
Fixes #117 

The current design will skip the validation of a `PortNamespace` if it
is not required *and* no values are passed for it upon process creation.
However, before validation, the inputs are pre-processed. This entails
that the input dictionary is mapped onto the input port namespace and
any input that is not explicitly specified, but corresponds to a port
with a default, has the field populated with said default value.

This behavior, however, now makes it impossible to skip the validation
of a non-required port namespace by not specifying any inputs, as soon
as it contains any port with a default. Even if no inputs are passed,
the pre-processing will populate the defaults, which will trigger the
validation because the inputs for the namespace are no longer empty.

To make it possible to have non-required namespaces, that contain nested
ports with defaul values, optionally validated, we introduce a new port
namespace property: "lazy". If a `PortNamespace` is "lazy" the pre
processing will only be triggered if there are explicit inputs defined
for it. If this is not the case, the population of defaults is skipped.