### PR TITLE
`PortNamespace`: move namespace validator after port validation

### DIFF
--- a/test/test_port.py
+++ b/test/test_port.py
@@ -74,14 +74,16 @@ class TestPortNamespace(TestCase):
         """Test validate method of a `PortNamespace`."""
 
         def validator(port_values):
-            if port_values['integer'] < 0:
+            if port_values['explicit'] < 0 or port_values['dynamic'] < 0:
                 return 'Only positive integers allowed'
 
+        self.port_namespace['explicit'] = InputPort('explicit', valid_type=int)
         self.port_namespace.validator = validator
         self.port_namespace.valid_type = int
 
-        self.assertIsNone(self.port_namespace.validate({'integer': 5}))
-        self.assertIsNotNone(self.port_namespace.validate({'integer': -5}))
+        # The explicit ports will be validated first before the namespace validator is called.
+        self.assertIsNone(self.port_namespace.validate({'explicit': 1, 'dynamic': 5}))
+        self.assertIsNotNone(self.port_namespace.validate({'dynamic': -5}))
 
     def test_port_namespace_dynamic(self):
         """


### PR DESCRIPTION
Fixes #128 

Typically the namespace validator will be a compound validation of
values of ports within the namespace. If the validator is called before
the ports have been validated, the validator logic cannot assume which
values will have been past and typically one will end up implementing
the validation of the ports again in the validator. By changing the
order the validator knows exactly what values should be present with
which types, since the validation of the ports will have passed.