### PR TITLE
 Add a context to the call of the `Port.validator`

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -34,7 +34,6 @@ from . import events
 from . import persistence
 from . import process_comms
 from . import process_states
-from . import ports
 from . import utils
 
 # pylint: disable=too-many-lines
@@ -645,7 +644,10 @@ class Process(StateMachine, persistence.Savable):
         # This will parse the inputs with respect to the input portnamespace of the spec and validate them
         raw_inputs = dict(self._raw_inputs) if self._raw_inputs else {}
         self._parsed_inputs = self.spec().inputs.pre_process(raw_inputs)
-        result = self.spec().inputs.validate(self._parsed_inputs)
+
+        # Pass a shallow clone of the parsed inputs as the `context`, to prevent validators altering the parsed inputs
+        context = copy.copy(self._parsed_inputs)
+        result = self.spec().inputs.validate(self._parsed_inputs, context)
 
         if result is not None:
             raise ValueError(result)

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -17,6 +17,17 @@ class TestInputPort(TestCase):
     def test_validator(self):
         """Test the validator functionality."""
 
+        def integer_validator(value, ctx):
+            if value < 0:
+                return 'Only positive integers allowed'
+
+        port = InputPort('test', validator=integer_validator)
+        self.assertIsNone(port.validate(5))
+        self.assertIsNotNone(port.validate(-5))
+
+    def test_validator_depreacted(self):
+        """Test the validator functionality."""
+
         def integer_validator(value):
             if value < 0:
                 return 'Only positive integers allowed'
@@ -73,7 +84,7 @@ class TestPortNamespace(TestCase):
     def test_port_namespace_validation(self):
         """Test validate method of a `PortNamespace`."""
 
-        def validator(port_values):
+        def validator(port_values, ctx):
             if port_values['explicit'] < 0 or port_values['dynamic'] < 0:
                 return 'Only positive integers allowed'
 


### PR DESCRIPTION
Fixes #126 

The context will contain the entire input mapping as passed to the top
level namespace at process instantiation. This is useful because often
validators perform validation on a combination of inputs and so in
addition to the value passed to the port of the validator itself, it
will need the inputs of other ports in the namespace as well.

The `Process` constructor passes a shallow copy of the parsed inputs as
the context to the process spec validation. This is because the parsed
inputs should not be altered and if it were passed by reference, the
validators could actually change it.