### PR TITLE
Raise `ImportError` for `DefaultObjectLoader.load_object`

### DIFF
--- a/plumpy/loaders.py
+++ b/plumpy/loaders.py
@@ -48,13 +48,13 @@ class DefaultObjectLoader(ObjectLoader):
         mod, name = identifier.split(":")
         try:
             mod = importlib.import_module(mod)
-        except ImportError as e:
-            raise ValueError("module '{}' from identifier '{}' could not be loaded".format(mod, identifier))
+        except ImportError:
+            raise ImportError("module '{}' from identifier '{}' could not be loaded".format(mod, identifier))
         else:
             try:
                 return getattr(mod, name)
             except AttributeError:
-                raise ValueError("object '{}' form identifier '{}' could not be loaded".format(name, identifier))
+                raise ImportError("object '{}' form identifier '{}' could not be loaded".format(name, identifier))
 
     def identify_object(self, obj):
         identifier = "{}:{}".format(obj.__module__, obj.__name__)

--- a/test/test_class_loader.py
+++ b/test/test_class_loader.py
@@ -7,6 +7,7 @@ class MyCls(object):
 
 
 class TestDefaultObjectLoader(unittest.TestCase):
+
     def test_simple_load(self):
         loader = plumpy.DefaultObjectLoader()
         identifier = loader.identify_object(MyCls)
@@ -14,7 +15,9 @@ class TestDefaultObjectLoader(unittest.TestCase):
         self.assertIs(MyCls, cls)
 
     def test_custom_loader(self):
+
         class CustomClassLoader(plumpy.ObjectLoader):
+
             def identify_object(self, obj):
                 if obj is MyCls:
                     return 'MyCls'
@@ -26,3 +29,11 @@ class TestDefaultObjectLoader(unittest.TestCase):
         loader = CustomClassLoader()
         cls = loader.load_object(loader.identify_object(MyCls))
         self.assertIs(MyCls, cls)
+
+    def test_load_failure(self):
+        loader = plumpy.DefaultObjectLoader()
+        identifier = loader.identify_object(MyCls)
+        broken_identifer = identifier + 'NotExistingClass'
+
+        with self.assertRaises(ImportError):
+            loader.load_object(broken_identifer)


### PR DESCRIPTION
Fixes #123 

The `ValueError` is a bit too generic and callers might mistakenly catch
other exceptions when trying to catch problems caused by the object
loader.