### PR TITLE
Update `pyyaml` to prevent arbitrary code execution

### DIFF
--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -348,7 +348,7 @@ class Excepted(State):
 
     def load_instance_state(self, saved_state, load_context):
         super(Excepted, self).load_instance_state(saved_state, load_context)
-        self.exception = yaml.load(saved_state[self.EXC_VALUE], Loader=yaml.Loader)
+        self.exception = yaml.load(saved_state[self.EXC_VALUE], Loader=yaml.FullLoader)
         if _HAS_TBLIB:
             try:
                 self.traceback = \

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='plumpy',
       install_requires=[
           'frozendict',
           'tornado>=4.1, <5.0',
-          'PyYAML>=3.13'
+          'pyyaml~=5.1.2',
           'pika>=1.0.0',
           'kiwipy[rmq]>=0.5.2',
           'enum34; python_version<"3.4"',

--- a/test/test_persistence.py
+++ b/test/test_persistence.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import plumpy
 from plumpy import test_utils
 import unittest
@@ -12,6 +13,7 @@ class SaveEmpty(plumpy.Savable):
 
 @plumpy.auto_persist('test', 'test_method')
 class Save1(plumpy.Savable):
+
     def __init__(self):
         self.test = 'sup yp'
         self.test_method = self.m
@@ -22,11 +24,13 @@ class Save1(plumpy.Savable):
 
 @plumpy.auto_persist('test')
 class Save(plumpy.Savable):
+
     def __init__(self):
         self.test = Save1()
 
 
 class TestSavable(unittest.TestCase):
+
     def test_empty_savable(self):
         self._save_round_trip(SaveEmpty())
 


### PR DESCRIPTION
Fixes #139 

Before `pyyaml==5.1` the `yaml.load` function was vulnerable to
arbitrary code execution, because it loaded the full set of YAML. There
was an alternative `safe_load` but this was not the default and could
only load a sub set of the markup language. The new version of pyyaml
deprecates the old vulnerable code and provides the `FullLoader` that
can load the full set without being vulnerable. The `safe_load` is
syntactic sugar for `load` with `Loader=FullLoader`.