### PR TITLE
`PortNamespace`: do not set `dynamic=False` when `valid_type=None`

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -377,9 +377,7 @@ class PortNamespace(collections.abc.MutableMapping, Port):
 
         :param valid_type: a tuple or single valid type that the namespace accepts
         """
-        if valid_type is None:
-            self.dynamic = False
-        else:
+        if valid_type is not None:
             self.dynamic = True
 
         super(PortNamespace, self.__class__).valid_type.fset(self, valid_type)  # pylint: disable=no-member
@@ -512,10 +510,7 @@ class PortNamespace(collections.abc.MutableMapping, Port):
         # Overload mutable attributes of PortNamespace unless overridden by value in namespace_options
         for attr in dir(port_namespace):
             if is_mutable_property(PortNamespace, attr):
-                if attr in namespace_options:
-                    setattr(self, attr, namespace_options.pop(attr))
-                else:
-                    setattr(self, attr, getattr(port_namespace, attr))
+                setattr(self, attr, namespace_options.pop(attr, getattr(port_namespace, attr)))
 
         if namespace_options:
             raise ValueError(

--- a/test/test_expose.py
+++ b/test/test_expose.py
@@ -73,6 +73,26 @@ class TestExposeProcess(utils.TestCaseWithLoop):
 
         self.assertEqual(port_namespace_left.__dict__, port_namespace_right.__dict__)
 
+    def test_expose_dynamic(self):
+        """Test that exposing a dynamic namespace remains dynamic."""
+
+        class Lower(Process):
+
+            @classmethod
+            def define(cls, spec):
+                super(Lower, cls).define(spec)
+                spec.input_namespace('foo', dynamic=True)
+
+        class Upper(Process):
+
+            @classmethod
+            def define(cls, spec):
+                super(Upper, cls).define(spec)
+                spec.expose_inputs(Lower)
+
+        self.assertTrue(Lower.spec().inputs['foo'].dynamic)
+        self.assertTrue(Upper.spec().inputs['foo'].dynamic)
+
     def test_expose_nested_namespace(self):
         """Test that expose_inputs can create nested namespaces while maintaining own ports."""
         inputs = self.ExposeProcess.spec().inputs

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -216,13 +216,12 @@ class TestPortNamespace(TestCase):
             self.port_namespace.create_port_namespace('sub.nested.space.' + self.BASE_PORT_NAME + '.further')
 
     def test_port_namespace_set_valid_type(self):
-        """
-        Setting a valid type for a PortNamespace should automatically mark it as dynamic. Conversely, setting
-        the valid_type equal to None should revert dynamic to False
-        """
+        """Setting a valid type for a PortNamespace should automatically mark it as dynamic."""
         self.assertFalse(self.port_namespace.dynamic)
         self.assertIsNone(self.port_namespace.valid_type)
 
+        # Setting the `valid_type` should automatically set `dynamic=True` because it does not make sense to define a
+        # a specific type but then not allow any values whatsoever.
         self.port_namespace.valid_type = int
 
         self.assertTrue(self.port_namespace.dynamic)
@@ -230,7 +229,8 @@ class TestPortNamespace(TestCase):
 
         self.port_namespace.valid_type = None
 
-        self.assertFalse(self.port_namespace.dynamic)
+        # Setting `valid_type` to `None` however does not automatically revert the `dynamic` attribute
+        self.assertTrue(self.port_namespace.dynamic)
         self.assertIsNone(self.port_namespace.valid_type)
 
     def test_port_namespace_validate(self):


### PR DESCRIPTION
Fixes #135 

When setting `valid_type` to anything but `None` the setter will
automatically also set `dynamic` to `True`, because this almost always
what one wants and so saves having to set this attribute explicitly.
Setting a valid type for a namespace but then not allowing any value
whatsoever is non-sensical.

The `valid_type` setter also implemented the reverse, meaning that
setting `valid_type=None` would automatically set `dynamic=False`. This
use case is a lot less common and actually leads to a lot of problems
since the default `valid_type` of a namespace is `None`. When exposing a
namespace that is dynamic, but without a particular `valid_type`, which
is perfectly fine logically - it just accepts any value, the exposed
namespace would lose its dynamicity. This is because the `valid_type`
would be set after the `dynamic`, resetting it to `False` because the
`valid_type` is `None`.