### PR TITLE
Fix the `LoopCommunicator.remove_broadcast_subscriber`

### DIFF
--- a/plumpy/communications.py
+++ b/plumpy/communications.py
@@ -87,10 +87,7 @@ def wrap_communicator(communicator, loop=None):
 
 
 class LoopCommunicator(kiwipy.Communicator):
-    """
-    This wrapper takes a kiwipy Communicator and schedules any subscriber messages on a given
-    event loop.
-    """
+    """Wrapper around a `kiwipy.Communicator` that schedules any subscriber messages on a given event loop."""
 
     def __init__(self, communicator, loop=None):
         """
@@ -125,12 +122,10 @@ class LoopCommunicator(kiwipy.Communicator):
 
     def add_broadcast_subscriber(self, subscriber, identifier=None):
         converted = convert_to_comm(subscriber, self._loop)
-        identifier = self._communicator.add_broadcast_subscriber(converted, identifier)
-        self._subscribers[identifier] = converted
-        return identifier
+        return self._communicator.add_broadcast_subscriber(converted, identifier)
 
     def remove_broadcast_subscriber(self, identifier):
-        self._communicator.remove_task_subscriber(self._subscribers.pop(identifier))
+        self._communicator.remove_broadcast_subscriber(identifier)
 
     def task_send(self, task, no_reply=False):
         return self._communicator.task_send(task, no_reply)

--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -9,7 +9,7 @@ import warnings
 
 from plumpy.utils import is_mutable_property, type_check
 
-__all__ = ['UNSPECIFIED', 'PortValidationError', 'Port', 'InputPort', 'OutputPort']
+__all__ = ['UNSPECIFIED', 'PortValidationError', 'PortNamespace', 'Port', 'InputPort', 'OutputPort']
 
 _LOGGER = logging.getLogger(__name__)
 UNSPECIFIED = ()
@@ -231,7 +231,7 @@ class InputPort(Port):
         )
 
         if required is not InputPort.required_override(required, default):
-            _LOGGER.info(
+            _LOGGER.debug(
                 "the required attribute for the input port '%s' was overridden because a default was specified", name
             )
 

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -633,14 +633,13 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         if self._communicator:
             from_label = from_state.LABEL.value if from_state is not None else None
+            subject = 'state_changed.{}.{}'.format(from_label, self.state.value)
+            self.logger.info('Broadcasting state change of %d: %s', self.pid, subject)
             try:
-                self._communicator.broadcast_send(
-                    body=None, sender=self.pid, subject='state_changed.{}.{}'.format(from_label, self.state.value)
-                )
+                self._communicator.broadcast_send(body=None, sender=self.pid, subject=subject)
             except ConnectionClosed:
-                self.logger.info(
-                    'no connection available to broadcast state change from %s to %s', from_label, self.state.value
-                )
+                message = 'no connection available to broadcast state change from %s to %s'
+                self.logger.info(message, from_label, self.state.value)
 
     def on_exiting(self):
         state = self.state

--- a/plumpy/utils.py
+++ b/plumpy/utils.py
@@ -12,7 +12,7 @@ import frozendict
 from .settings import check_protected, check_override
 from . import lang
 
-__all__ = []
+__all__ = ['AttributesDict']
 
 protected = lang.protected(check=check_protected)  # pylint: disable=invalid-name
 override = lang.override(check=check_override)  # pylint: disable=invalid-name

--- a/test/test_communications.py
+++ b/test/test_communications.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`plumpy.communications` module."""
+import pytest
+
+from kiwipy import CommunicatorHelper
+from plumpy.communications import LoopCommunicator
+
+
+class Subscriber:
+    """Test class that mocks a subscriber."""
+
+
+class Communicator(CommunicatorHelper):
+
+    def task_send(self, task, no_reply=False):
+        pass
+
+    def rpc_send(self, recipient_id, msg):
+        pass
+
+    def broadcast_send(self, body, sender=None, subject=None, correlation_id=None):
+        pass
+
+
+@pytest.fixture
+def loop_communicator():
+    """Return an instance of `LoopCommunicator`."""
+    return LoopCommunicator(Communicator())
+
+
+@pytest.fixture
+def subscriber():
+    """Return an instance of `Subscriber`."""
+    return Subscriber()
+
+
+@pytest.mark.skip('Re-enable when https://github.com/aiidateam/kiwipy/issues/61 is resolved.')
+def test_add_rpc_subscriber(loop_communicator, subscriber):
+    """Test the `LoopCommunicator.add_rpc_subscriber` method."""
+    assert loop_communicator.add_rpc_subscriber(subscriber) is not None
+
+    identifier = 'identifier'
+    assert loop_communicator.add_rpc_subscriber(subscriber, identifier) == identifier
+
+
+@pytest.mark.skip('Re-enable when https://github.com/aiidateam/kiwipy/issues/61 is resolved.')
+def test_remove_rpc_subscriber(loop_communicator, subscriber):
+    """Test the `LoopCommunicator.remove_rpc_subscriber` method."""
+    identifier = loop_communicator.add_rpc_subscriber(subscriber)
+    loop_communicator.remove_rpc_subscriber(identifier)
+
+
+def test_add_broadcast_subscriber(loop_communicator, subscriber):
+    """Test the `LoopCommunicator.add_broadcast_subscriber` method."""
+    assert loop_communicator.add_broadcast_subscriber(subscriber) is not None
+
+    identifier = 'identifier'
+    assert loop_communicator.add_broadcast_subscriber(subscriber, identifier) == identifier
+
+
+def test_remove_broadcast_subscriber(loop_communicator, subscriber):
+    """Test the `LoopCommunicator.remove_broadcast_subscriber` method."""
+    identifier = loop_communicator.add_broadcast_subscriber(subscriber)
+    loop_communicator.remove_broadcast_subscriber(identifier)
+
+
+def test_add_task_subscriber(loop_communicator, subscriber):
+    """Test the `LoopCommunicator.add_task_subscriber` method."""
+    assert loop_communicator.add_task_subscriber(subscriber) is None
+
+
+def test_remove_task_subscriber(loop_communicator, subscriber):
+    """Test the `LoopCommunicator.remove_task_subscriber` method."""
+    loop_communicator.add_task_subscriber(subscriber)
+    loop_communicator.remove_task_subscriber(subscriber)


### PR DESCRIPTION
Fixes #155 

The `remove_broadcast_subscriber` method was piping through to the
`remove_task_subscriber` method, which is probably a copy and paste
error that went unnoticed because the entire class was unused and
untested.

Also change the logging level when required attribute of a `Port` is
overridden by a default from `INFO` to `DEBUG` as this is a very common
operation and was way too noisy.