### PR TITLE
Update dependency requirement to `kiwipy~=0.5.5`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'tornado>=4.1, <5.0',
         'pyyaml~=5.1.2',
         'pika>=1.0.0',
-        'kiwipy[rmq]~=0.5.4',
+        'kiwipy[rmq]~=0.5.5',
     ],
     extras_require={
         'docs': [

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:frozendict:
+    ignore::DeprecationWarning:tornado:

--- a/test/test_communications.py
+++ b/test/test_communications.py
@@ -34,7 +34,6 @@ def subscriber():
     return Subscriber()
 
 
-@pytest.mark.skip('Re-enable when https://github.com/aiidateam/kiwipy/issues/61 is resolved.')
 def test_add_rpc_subscriber(loop_communicator, subscriber):
     """Test the `LoopCommunicator.add_rpc_subscriber` method."""
     assert loop_communicator.add_rpc_subscriber(subscriber) is not None
@@ -43,7 +42,6 @@ def test_add_rpc_subscriber(loop_communicator, subscriber):
     assert loop_communicator.add_rpc_subscriber(subscriber, identifier) == identifier
 
 
-@pytest.mark.skip('Re-enable when https://github.com/aiidateam/kiwipy/issues/61 is resolved.')
 def test_remove_rpc_subscriber(loop_communicator, subscriber):
     """Test the `LoopCommunicator.remove_rpc_subscriber` method."""
     identifier = loop_communicator.add_rpc_subscriber(subscriber)


### PR DESCRIPTION
Fixes #162 

The `CommunicatorHelper.add_rpc_subscriber` does not return the
identifier for `kiwipy<0.5.5`.

Add a `pytest.ini` file to ignore deprecation warnings that are being
thrown by third party libraries calling the deprecated code. These are
not warnings that we can or should address.