### PR TITLE
CI: Update `setup-python` action to v2 in order to pin Python to 3.7.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
                     pip-docs-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -52,7 +52,7 @@ jobs:
                     pip-pre-commit-
 
         -   name: Set up Python
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: 3.8
 
@@ -70,7 +70,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7, 3.8]
+                python-version: [3.5, 3.6, 3.7.7, 3.8]
 
         services:
             rabbitmq:
@@ -91,7 +91,7 @@ jobs:
                     pip-${{ matrix.python-version }}-tests
 
         -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v1
+            uses: actions/setup-python@v2
             with:
                 python-version: ${{ matrix.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,14 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 
+-   repo: https://github.com/pre-commit/mirrors-yapf
+    rev: v0.30.0
+    hooks:
+    -   id: yapf
+        name: yapf
+        types: [python]
+        args: ['-i']
+
 -   repo: https://github.com/PyCQA/pylint
     rev: pylint-2.5.2
     hooks:
@@ -31,11 +39,3 @@ repos:
                 docs/source/conf.py|
                 test/.*|
             )$
-
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
-    hooks:
-    -   id: yapf
-        name: yapf
-        types: [python]
-        args: ['-i']

--- a/plumpy/persistence.py
+++ b/plumpy/persistence.py
@@ -51,7 +51,7 @@ class Bundle(dict):
         return Savable.load(self, load_context)
 
 
-_BUNDLE_TAG = u'!plumpy:Bundle'
+_BUNDLE_TAG = '!plumpy:Bundle'
 
 
 def _bundle_representer(dumper, node):


### PR DESCRIPTION
Python 3.7.8, which was installed by default has some issues with our
requirement for `pyyaml==5.1.2`. Since we cannot release this requirement
very easily, we temporarily workaround it by pinning 3.7.7 for the tests
job, which is the only job requiring Python 3.7. Note that this required
`setup-python@v2` since v1 does not allow specifying an exact version.

Also move `yapf` to run before `pylint` in the pre-commit, such that
pylint won't complain about formatting that would have been fixed anyway
by `yapf`.