### PR TITLE
ci: unpin action python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.5, 3.6, 3.7.7, 3.8]
+                python-version: [3.5, 3.6, 3.7, 3.8]
 
         services:
             rabbitmq:


### PR DESCRIPTION
the github action issues is fixed. So 3.7.7
python version pining can be removed. 

https://github.com/actions/virtual-environments/issues/1202#issuecomment-670157812