### PR TITLE
Suppress exception thrown in generator exit in `create_task`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,4 +61,3 @@
 ### Bug fixes
 - Fix bug in process spec validation with default and validator [[#106]](https://github.com/aiidateam/aiida-core/pull/106)
 - Fix call of `Portnamespace.validator` [[#104]](https://github.com/aiidateam/aiida-core/pull/104)
-


### PR DESCRIPTION
Fixes #168 

Due to a bug in `contextlib._GeneratorContextManager` in versions of
Python before 3.8, once the context manager in the `run_task` coroutine
of the `futures.create_task` utility the following exception is printed
as soon as the loop is close:

    Exception ignored in: <generator object create_task.<locals>.run_task>
    Traceback (most recent call last):
      File "../plumpy/plumpy/futures.py", line 102, in run_task
      File "/usr/lib/python3.7/contextlib.py", line 158, in __exit__
    AttributeError: 'NoneType' object has no attribute 'exc_info'

This exception is thrown because somehow the `sys` module is already
`None`. The only real fix would be to fix the `contextlib` module but
since this is not feasible, a workaround is introduced here that catches
this specific exception and simply suppresses it.