### PR TITLE
Dependencies: relax the requirement of `aio-pika`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords='workflow multithreaded rabbitmq',
     python_requires='>=3.5',
     install_requires=[
-        'frozendict~=1.2', 'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6.1', 'aiocontextvars~=0.2.2',
+        'frozendict~=1.2', 'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6', 'aiocontextvars~=0.2.2',
         'kiwipy[rmq]~=0.6.0'
     ],
     extras_require={


### PR DESCRIPTION
The requirement was `aio-pika~=6.6.1` which means that the minor version
was restricted. However, for stable packages, it is often most
reasonable to allow any minor version of a particular major version,
since those should guarantee backwards compatibility.