### PR TITLE
`Port`: do not call validator if unspecified and port not required

### DIFF
--- a/plumpy/ports.py
+++ b/plumpy/ports.py
@@ -188,7 +188,7 @@ class Port:
                 self.name, type(value), self._valid_type
             )
 
-        if not validation_error and self._validator is not None:
+        if not validation_error and self._validator is not None and value is not UNSPECIFIED:
             spec = inspect.getfullargspec(self.validator)
             if len(spec[0]) == 1:
                 warnings.warn(VALIDATOR_SIGNATURE_DEPRECATION_WARNING.format(self.validator.__name__))

--- a/test/test_port.py
+++ b/test/test_port.py
@@ -32,6 +32,16 @@ class TestPort(TestCase):
         self.assertIsNone(spec.validate(5))
         self.assertIsNotNone(spec.validate('s'))
 
+    def test_validator_not_required(self):
+        """Verify that a validator is not called if no value is specified for a port that is not required."""
+
+        def validate(value, port):
+            raise RuntimeError
+
+        spec = Port('valid_with_validator', validator=validate, required=False)
+
+        self.assertIsNone(spec.validate(UNSPECIFIED))
+
 
 class TestInputPort(TestCase):
 
@@ -153,6 +163,10 @@ class TestPortNamespace(TestCase):
         # The explicit ports will be validated first before the namespace validator is called.
         self.assertIsNone(self.port_namespace.validate({'explicit': 1, 'dynamic': 5}))
         self.assertIsNotNone(self.port_namespace.validate({'dynamic': -5}))
+
+        # Validator should not be called if the namespace is not required and no value is specified for the namespace
+        self.port_namespace.required = False
+        self.assertIsNone(self.port_namespace.validate())
 
     def test_port_namespace_dynamic(self):
         """


### PR DESCRIPTION
Fixes #172 

If no value is specified for a non-required port, the validator should
not be called because there is nothing to be validated. The current
behavior of calling the validator regardless, forces all validators to
deal with the `UNSPECIFIED` value that is passed, but this is a global
constant that should remain internal to `plumpy` and not be used by
client code.