### PR TITLE
Make application of `nest_asyncio` patch explicit

### DIFF
--- a/plumpy/__init__.py
+++ b/plumpy/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 from .loaders import *
 from .communications import *
+from .events import *
 from .exceptions import *
 from .futures import *
 from .persistence import *
@@ -18,9 +19,9 @@ from .version import *
 from .workchains import *
 
 __all__ = (
-    exceptions.__all__ + processes.__all__ + utils.__all__ + futures.__all__ + mixins.__all__ + persistence.__all__ +
-    communications.__all__ + process_comms.__all__ + version.__all__ + process_listener.__all__ + workchains.__all__ +
-    loaders.__all__ + ports.__all__ + process_states.__all__
+    events.__all__ + exceptions.__all__ + processes.__all__ + utils.__all__ + futures.__all__ + mixins.__all__ +
+    persistence.__all__ + communications.__all__ + process_comms.__all__ + version.__all__ + process_listener.__all__ +
+    workchains.__all__ + loaders.__all__ + ports.__all__ + process_states.__all__
 )
 
 

--- a/plumpy/events.py
+++ b/plumpy/events.py
@@ -3,11 +3,62 @@
 import sys
 import asyncio
 
-__all__ = ['new_event_loop', 'set_event_loop', 'get_event_loop', 'run_until_complete']
+__all__ = [
+    'new_event_loop', 'set_event_loop', 'get_event_loop', 'run_until_complete', 'set_event_loop_policy',
+    'reset_event_loop_policy', 'PlumpyEventLoopPolicy'
+]
 
 get_event_loop = asyncio.get_event_loop  # pylint: disable=invalid-name
-new_event_loop = asyncio.new_event_loop  # pylint: disable=invalid-name
-set_event_loop = asyncio.set_event_loop  # pylint: disable=invalid-name
+
+
+def set_event_loop(*args, **kwargs):
+    raise NotImplementedError('this method is not implemented because `plumpy` uses a single reentrant loop')
+
+
+def new_event_loop(*args, **kwargs):
+    raise NotImplementedError('this method is not implemented because `plumpy` uses a single reentrant loop')
+
+
+class PlumpyEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
+    """Custom event policy that always returns the same event loop that is made reentrant by ``nest_asyncio``."""
+
+    _loop = None
+
+    def get_event_loop(self):
+        """Return the patched event loop."""
+        import nest_asyncio
+
+        if self._loop is None:
+            self._loop = super().get_event_loop()
+            nest_asyncio.apply(self._loop)
+
+        return self._loop
+
+
+def set_event_loop_policy():
+    """Enable plumpy's event loop policy that will make event loop's reentrant."""
+    asyncio.set_event_loop_policy(PlumpyEventLoopPolicy())
+
+
+def reset_event_loop_policy():
+    """Reset the event loop policy to the default."""
+    loop = get_event_loop()
+
+    # pylint: disable=protected-access
+    cls = loop.__class__
+    cls._run_once = cls._run_once_orig
+    cls.run_forever = cls._run_forever_orig
+    cls.run_until_complete = cls._run_until_complete_orig
+
+    del cls._check_running
+    del cls._check_runnung  # typo in Python 3.7 source
+    del cls._run_once_orig
+    del cls._run_forever_orig
+    del cls._run_until_complete_orig
+    del cls._nest_patched
+    # pylint: enable=protected-access
+
+    asyncio.set_event_loop_policy(None)
 
 
 def run_until_complete(future, loop=None):

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -15,7 +15,6 @@ from aiocontextvars import ContextVar
 from aio_pika.exceptions import ConnectionClosed
 import yaml
 import kiwipy
-import nest_asyncio
 
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -241,7 +240,6 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         self.spec().seal()
 
         self._loop = loop if loop is not None else asyncio.get_event_loop()
-        nest_asyncio.apply(self._loop)
 
         self._setup_event_hooks()
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+@pytest.fixture(scope='session')
+def set_event_loop_policy():
+    from plumpy import set_event_loop_policy
+    set_event_loop_policy()

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Tests for the :mod:`plumpy.events` module."""
+import asyncio
+
+import pytest
+
+from plumpy import set_event_loop_policy, reset_event_loop_policy, PlumpyEventLoopPolicy, set_event_loop, new_event_loop
+
+
+def test_set_event_loop_policy():
+    """Test the ``plumpy.set_event_loop_policy``."""
+    assert not isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
+    set_event_loop_policy()
+    assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
+
+
+def test_reset_event_loop_policy():
+    """Test the ``plumpy.reset_event_loop_policy``."""
+    set_event_loop_policy()
+    assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
+    reset_event_loop_policy()
+    assert not isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
+
+
+def test_get_event_loop():
+    """Test that ``asyncio.get_event_loop`` returns same loop instance every time it is called once policy is set."""
+    set_event_loop_policy()
+    assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
+    assert asyncio.get_event_loop() is asyncio.get_event_loop()
+    assert asyncio.get_event_loop()._nest_patched is not None
+
+
+def test_set_event_loop():
+    """Test the ``set_event_loop`` raises ``NotImplementedError``."""
+    with pytest.raises(NotImplementedError):
+        set_event_loop()
+
+
+def test_new_event_loop():
+    """Test the ``new_event_loop`` raises ``NotImplementedError``."""
+    with pytest.raises(NotImplementedError):
+        new_event_loop()


### PR DESCRIPTION
Fixes #178 

A new event loop policy is implemented `PlumpyEventLoopPolicy` which
overrides the `get_event_loop` method to return an event loop that is
patched with the `nest_asyncio` library to make it reentrant. It also
makes sure that it always returns the same event loop because once made
reentrant, only a single one is required.

The policy now has to be enabled explicitly by calling the method
`set_event_loop_policy` instead of implicit, as it used to be done in
the constructor of the `Process` class. The event loop policy can be
reset through `reset_event_loop_policy`.