### PR TITLE
Dependencies: only require `aiocontextvars` for Python < 3.7

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -11,7 +11,11 @@ import uuid
 import asyncio
 from typing import Union
 
-from aiocontextvars import ContextVar
+try:
+    from aiocontextvars import ContextVar
+except ModuleNotFoundError:
+    from contextvars import ContextVar
+
 from aio_pika.exceptions import ConnectionClosed
 import yaml
 import kiwipy
@@ -399,8 +403,8 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         """
         try:
             return self._state.successful
-        except AttributeError:
-            raise exceptions.InvalidStateError('process is not in the finished state')
+        except AttributeError as exception:
+            raise exceptions.InvalidStateError('process is not in the finished state') from exception
 
     @property
     def is_successful(self):

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     keywords='workflow multithreaded rabbitmq',
     python_requires='>=3.5',
     install_requires=[
-        'frozendict~=1.2', 'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6', 'aiocontextvars~=0.2.2',
-        'kiwipy[rmq]~=0.6.0'
+        'frozendict~=1.2', 'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6',
+        'aiocontextvars~=0.2.2; python_version<"3.7"', 'kiwipy[rmq]~=0.6.0'
     ],
     extras_require={
         'docs': [


### PR DESCRIPTION
Not explicitly adding this upper limit is not a problem for normal
installations, however, for the conda version of the package this is
problematic. The conda feedstock explicitly states that the package can
only be used with Python versions smaller than 3.7 and attempting to
install with a more recent version will fail.