### PR TITLE
use asyncio.isfuture to check plum_future is unwrapped

### DIFF
--- a/plumpy/communications.py
+++ b/plumpy/communications.py
@@ -31,12 +31,12 @@ def plum_to_kiwi_future(plum_future):
 
     def on_done(_plum_future):
         with kiwipy.capture_exceptions(kiwi_future):
-            if plum_future.cancelled():
+            if _plum_future.cancelled():
                 kiwi_future.cancel()
             else:
-                result = plum_future.result()
+                result = _plum_future.result()
                 # Did we get another future?  In which case convert it too
-                if isinstance(result, futures.Future):
+                if asyncio.isfuture(result):
                     result = plum_to_kiwi_future(result)
                 kiwi_future.set_result(result)
 


### PR DESCRIPTION
- The `plum_future` passed in may wrap a `_asyncio.Future` which is not
   an instace of `plumpy.Future`. So `asyncio.isfuture` is indispensable here to 
   continue to unwrap the future to the final result.
- there is a typo in callback function `on_dnoe`. The augment is
  `_plum_future` with an underscore as its prefix while in the callback
  function there is not but use the unlocal `plum_future`.

As mentioned in https://github.com/aiidateam/aiida-core/issues/4595#issuecomment-735355618, I change it to `asyncio.isfuture` in aiida_core but forget there also the same issue in plumpy. Although this didn't cause any problem yet, may relate to some subtle problem. Moreover, the typo of `_plum_future` seems doesn't matter just because we didn't have a deeply wrapped future. It would be more make sense to adopt the modifies in this pull request.
