### PR TITLE
Trigger application of nest patch in `set_event_loop_policy`

### DIFF
--- a/plumpy/events.py
+++ b/plumpy/events.py
@@ -38,6 +38,9 @@ class PlumpyEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
 def set_event_loop_policy():
     """Enable plumpy's event loop policy that will make event loop's reentrant."""
     asyncio.set_event_loop_policy(PlumpyEventLoopPolicy())
+    # Need to call the following explicitly for `asyncio.get_event_loop` to start calling the method of the new policy
+    # in case an loop is already active.
+    asyncio.get_event_loop_policy().get_event_loop()
 
 
 def reset_event_loop_policy():

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
             'sphinx-rtd-theme==0.4.3',
         ],
         'pre-commit': ['pre-commit~=2.2', 'pylint==2.5.2'],
-        'tests': ['pytest~=5.4', 'shortuuid', 'pytest-asyncio']
+        'tests': ['pytest~=5.4', 'shortuuid', 'pytest-asyncio', 'pytest-notebook']
     },
     packages=['plumpy', 'plumpy/base'],
     test_suite='test'

--- a/test/notebooks/get_event_loop.ipynb
+++ b/test/notebooks/get_event_loop.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "from plumpy import set_event_loop_policy, PlumpyEventLoopPolicy\n",
+    "set_event_loop_policy()\n",
+    "assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)\n",
+    "assert hasattr(asyncio.get_event_loop(), '_nest_patched')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`plumpy.events` module."""
 import asyncio
+import pathlib
 
 import pytest
 
@@ -40,3 +41,12 @@ def test_new_event_loop():
     """Test the ``new_event_loop`` raises ``NotImplementedError``."""
     with pytest.raises(NotImplementedError):
         new_event_loop()
+
+
+def test_get_event_loop_jupyter_notebook(nb_regression):
+    """Test that ``asyncio.get_event_loop`` returns same loop instance every time it is called once policy is set."""
+    nb_regression.diff_color_words = False
+    nb_regression.diff_ignore = ('/metadata/language_info/version',)
+
+    with open(pathlib.Path(__file__).parent / 'notebooks' / 'get_event_loop.ipynb') as handle:
+        nb_regression.check(handle)


### PR DESCRIPTION
Fixes #188 

The `PlumpyEventLoopPolicy` is designed to apply the `nest_asyncio`
patch to the event loop to make it reentrant. Once the policy is applied
using `set_event_loop_policy` the idea is that when calling
`asyncio.get_event_loop` the `get_event_loop` of `PlumpyEventLoopPolicy`
is called instead which will apply the patch to the loop if not already
done before.

However, in a Jupyter notebook, `asyncio.get_event_loop` would not
actually call the patched `get_event_loop` of the policy, even do the
policy was set. This was proved by the fact that calling the method
`asyncio.get_event_loop_policy` would return `PlumpyEventLoopPolicy`. It
was not until `asyncio.get_event_loop_policy().get_event_loop()` was
called that the patch policy was called and the loop was patched.

As a workaround the `set_event_loop_policy` is updated to directly after
setting the new policy to call `get_event_loop_policy`. Through an
unknown mechanism, this forces that `asyncio.get_event_loop` will
actually start to call the implementation of the new policy.