### PR TITLE
🐛 FIX: Allow for dereferencing of saved instance state

### DIFF
--- a/plumpy/mixins.py
+++ b/plumpy/mixins.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 from typing import Any
 
 from .utils import AttributesDict, Optional
@@ -28,9 +27,16 @@ class ContextMixin(persistence.Savable):
     def save_instance_state(
         self, out_state: SAVED_STATE_TYPE, save_context: Optional[persistence.LoadSaveContext]
     ) -> None:
+        """Add the instance state to ``out_state``.
+        
+        .. important::
+
+            The instance state will contain a pointer to the ``ctx``,
+            and so should be deep copied or serialised before persisting.
+        """
         super().save_instance_state(out_state, save_context)
         if self._context is not None:
-            out_state[self.CONTEXT] = copy.copy(self._context.__dict__)
+            out_state[self.CONTEXT] = self._context.__dict__
 
     def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
         super().load_instance_state(saved_state, load_context)

--- a/plumpy/mixins.py
+++ b/plumpy/mixins.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import copy
 from typing import Any
 
 from .utils import AttributesDict, Optional
@@ -29,7 +30,7 @@ class ContextMixin(persistence.Savable):
     ) -> None:
         super().save_instance_state(out_state, save_context)
         if self._context is not None:
-            out_state[self.CONTEXT] = self._context.__dict__
+            out_state[self.CONTEXT] = copy.copy(self._context.__dict__)
 
     def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
         super().load_instance_state(saved_state, load_context)

--- a/plumpy/mixins.py
+++ b/plumpy/mixins.py
@@ -28,7 +28,6 @@ class ContextMixin(persistence.Savable):
         self, out_state: SAVED_STATE_TYPE, save_context: Optional[persistence.LoadSaveContext]
     ) -> None:
         """Add the instance state to ``out_state``.
-        
         .. important::
 
             The instance state will contain a pointer to the ``ctx``,


### PR DESCRIPTION
As a toy example:

```python
import plumpy

persister = plumpy.InMemoryPersister()

class PersistWorkChain(plumpy.WorkChain):

    @classmethod
    def define(cls, spec):
        super().define(spec)
        spec.outline(
            cls.step1,
            cls.step2,
        )
        
    def step1(self):
        self.ctx.step = 1
        persister.save_checkpoint(self, 'step1')

    def step2(self):
        self.ctx.step = 2
        persister.save_checkpoint(self, 'step2')

        
workchain = PersistWorkChain()
workchain.execute()
{k: v['_context'] for k, v in persister._checkpoints[workchain.pid].items()}
```

```
{'step1': {'step': 2}, 'step2': {'step': 2}}
```

This obviously won't affect Persisters that serialize the data, but it is definitely a bug in this instance.

Strictly we should use `copy.deepcopy`, but this could run into issues if a value was not pickleable, and then I'm not sure how exceptions should be handled