### PR TITLE
🔧 MAINTAIN: Remove frozendict dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       hooks:
           - id: pylint
             additional_dependencies: [
-                "frozendict~=1.2", "pyyaml~=5.1.2", "nest_asyncio~=1.4.0", "aio-pika~=6.6",
+                "pyyaml~=5.1.2", "nest_asyncio~=1.4.0", "aio-pika~=6.6",
                 "aiocontextvars~=0.2.2; python_version<'3.7'", "kiwipy[rmq]~=0.7.1"
             ]
             args:

--- a/plumpy/utils.py
+++ b/plumpy/utils.py
@@ -71,8 +71,10 @@ class EventHelper:
 
 class Frozendict(Mapping):
     """
-    An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`
+    An immutable wrapper around dictionaries that implements the complete :py:class:`collections.abc.Mapping`
     interface. It can be used as a drop-in replacement for dictionaries where immutability is desired.
+
+    Adapted from: slezica/python-frozendict
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     keywords='workflow multithreaded rabbitmq',
     python_requires='>=3.6',
     install_requires=[
-        'frozendict~=1.2', 'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6',
-        'aiocontextvars~=0.2.2; python_version<"3.7"', 'kiwipy[rmq]~=0.7.1'
+        'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6', 'aiocontextvars~=0.2.2; python_version<"3.7"',
+        'kiwipy[rmq]~=0.7.1'
     ],
     extras_require={
         'docs': ['sphinx~=3.2.0', 'myst-nb~=0.11.0', 'sphinx-book-theme~=0.0.39', 'ipython~=7.0'],

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,6 +2,7 @@
 """Utilities for tests"""
 import asyncio
 import collections
+from collections.abc import Mapping
 import shortuuid
 import unittest
 
@@ -370,7 +371,7 @@ def compare_dictionaries(bundle1, bundle2, dict1, dict2, exclude=None):
 
 
 def compare_value(bundle1, bundle2, v1, v2, exclude=None):
-    if isinstance(v1, collections.Mapping) and isinstance(v2, collections.Mapping):
+    if isinstance(v1, Mapping) and isinstance(v2, Mapping):
         compare_dictionaries(bundle1, bundle2, v1, v2, exclude)
     elif isinstance(v1, list) and isinstance(v2, list):
         for vv1, vv2 in zip(v1, v2):


### PR DESCRIPTION
This package has been unmaintained for years,
and now it raises issues with python 3.8
and will not work anymore in python 3.10

closes #203