### PR TITLE
👌 IMPROVE: Terminal states do not reference process

### DIFF
--- a/plumpy/base/state_machine.py
+++ b/plumpy/base/state_machine.py
@@ -125,11 +125,11 @@ class State:
     def is_terminal(cls) -> bool:
         return not cls.ALLOWED
 
-    def __init__(self, state_machine: 'StateMachine', *args: Any, **kwargs: Any):  # pylint: disable=unused-argument
+    def __init__(self, state_machine: Optional['StateMachine'], *args: Any, **kwargs: Any):  # pylint: disable=unused-argument
         """
         :param state_machine: The process this state belongs to
         """
-        self.state_machine = state_machine
+        self.state_machine: Optional[StateMachine] = state_machine
         self.in_state: bool = False
 
     def __str__(self) -> str:
@@ -157,6 +157,8 @@ class State:
             raise InvalidStateError('Cannot exit a terminal state {}'.format(self.LABEL))
 
     def create_state(self, state_label: Hashable, *args: Any, **kwargs: Any) -> 'State':
+        if self.state_machine is None:
+            raise ValueError('State machine not set for {self}')
         return self.state_machine.create_state(state_label, *args, **kwargs)
 
     def do_enter(self) -> None:

--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -145,6 +145,8 @@ class State(state_machine.State, persistence.Savable):
         """
         :return: The process
         """
+        if self.state_machine is None:
+            raise ValueError('Process not set for {self}')
         return self.state_machine
 
     def load_instance_state(self, saved_state: SAVED_STATE_TYPE, load_context: persistence.LoadSaveContext) -> None:
@@ -342,14 +344,17 @@ class Excepted(State):
     TRACEBACK = 'traceback'
 
     def __init__(
-        self, process: 'Process', exception: Optional[BaseException], trace_back: Optional[TracebackType] = None
+        self,
+        process: 'Process',  # pylint: disable=unused-argument
+        exception: Optional[BaseException],
+        trace_back: Optional[TracebackType] = None
     ):
         """
         :param process: The associated process
         :param exception: The exception instance
         :param trace_back: An optional exception traceback
         """
-        super().__init__(process)
+        super().__init__(None)  # terminal state does not require process ref
         self.exception = exception
         self.traceback = trace_back
 
@@ -389,8 +394,8 @@ class Excepted(State):
 class Finished(State):
     LABEL = ProcessState.FINISHED
 
-    def __init__(self, process: 'Process', result: Any, successful: bool) -> None:
-        super().__init__(process)
+    def __init__(self, process: 'Process', result: Any, successful: bool) -> None:  # pylint: disable=unused-argument
+        super().__init__(None)  # terminal state does not require process ref
         self.result = result
         self.successful = successful
 
@@ -399,13 +404,13 @@ class Finished(State):
 class Killed(State):
     LABEL = ProcessState.KILLED
 
-    def __init__(self, process: 'Process', msg: Optional[str]):
+    def __init__(self, process: 'Process', msg: Optional[str]):  # pylint: disable=unused-argument
         """
         :param process: The associated process
         :param msg: Optional kill message
 
         """
-        super().__init__(process)
+        super().__init__(None)  # terminal state does not require process ref
         self.msg = msg
 
 

--- a/plumpy/version.py
+++ b/plumpy/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-__version__: str = '0.18.4'
+__version__: str = '0.18.5a0'
 
 __all__ = ['__version__']


### PR DESCRIPTION
This removes any cyclic references in finished processes,
allowing for garbage collection to be be automatically triggered in CPython.

closes #198

I am going to create an alpha release from this branch, in order to test that this not lead to any issues in the aiida-core tests