### PR TITLE
🐛 FIX: retrieve future exception on_killed

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -823,6 +823,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
     def on_killed(self) -> None:
         """Entered the KILLED state."""
         self._killing = None
+        self.future().exception()  # exception must be retrieved
         self._fire_event(ProcessListener.on_process_killed, self.killed_msg())
 
     def on_terminated(self) -> None:


### PR DESCRIPTION
The exception set on the future by `on_kill` should be retrieved,
otherwise it will be caught by the loop's exception handler.

For example on aiida-core:

```python
tests/engine/test_rmq.py .......                                                                                                                                                              [100%]

========================================================================================= warnings summary ==========================================================================================
tests/engine/test_rmq.py: 21 warnings
  /Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/aio_pika/message.py:714: DeprecationWarning: Use "async with message.process()" instead
    warn('Use "async with message.process()" instead', DeprecationWarning)

tests/engine/test_rmq.py::TestProcessControl::test_pause_play
tests/engine/test_rmq.py::TestProcessControl::test_submit_simple
  /Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/asyncio/base_events.py:626: ResourceWarning: unclosed event loop <_UnixSelectorEventLoop running=False closed=False debug=True>
    source=self)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================== 7 passed, 23 warnings in 7.41s ===================================================================================
SavableFuture exception was never retrieved
future: <SavableFuture finished exception=KilledError('Sorry, you have to go mate') created at /Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/plumpy/processes.py:281>
source_traceback: Object created at (most recent call last):
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/config/__init__.py", line 185, in console_main
    code = main()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/config/__init__.py", line 163, in main
    config=config
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 316, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 269, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 323, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 348, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 109, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 126, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 215, in call_and_report
    call = call_runtest_hook(item, when, **kwds)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 255, in call_runtest_hook
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 311, in from_call
    result: Optional[TResult] = func()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 255, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 162, in pytest_runtest_call
    item.runtest()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/unittest.py", line 321, in runtest
    self._testcase(result=self)  # type: ignore[arg-type]
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/unittest/case.py", line 676, in __call__
    return self.run(*args, **kwds)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/unittest/case.py", line 628, in run
    testMethod()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/tests/engine/test_rmq.py", line 164, in test_kill
    self.runner.loop.run_until_complete(do_kill())
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 92, in run_until_complete
    self._run_once()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 132, in _run_once
    handle._run()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 201, in run
    ctx.run(self._callback, *self._args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 159, in step
    step_orig(task, exc)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 159, in step
    step_orig(task, exc)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/tests/engine/test_rmq.py", line 149, in do_kill
    calc_node = self.runner.submit(test_processes.WaitProcess)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/runners.py", line 184, in submit
    process_inited = self.instantiate_process(process, *args, **inputs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/runners.py", line 170, in instantiate_process
    return instantiate_process(self, process, *args, **inputs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/utils.py", line 65, in instantiate_process
    process = process_class(runner=runner, inputs=inputs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/plumpy/base/state_machine.py", line 192, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/processes/process.py", line 147, in __init__
    communicator=self._runner.communicator
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/plumpy/processes.py", line 281, in __init__
    self._future = persistence.SavableFuture(loop=self._loop)
plumpy.exceptions.KilledError: Sorry, you have to go mate
SavableFuture exception was never retrieved
future: <SavableFuture finished exception=KilledError('Sorry, you have to go mate') created at /Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/plumpy/processes.py:281>
source_traceback: Object created at (most recent call last):
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/config/__init__.py", line 185, in console_main
    code = main()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/config/__init__.py", line 163, in main
    config=config
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 316, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 269, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 323, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/main.py", line 348, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 109, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 126, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 215, in call_and_report
    call = call_runtest_hook(item, when, **kwds)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 255, in call_runtest_hook
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 311, in from_call
    result: Optional[TResult] = func()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 255, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/runner.py", line 162, in pytest_runtest_call
    item.runtest()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/_pytest/unittest.py", line 321, in runtest
    self._testcase(result=self)  # type: ignore[arg-type]
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/unittest/case.py", line 676, in __call__
    return self.run(*args, **kwds)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/unittest/case.py", line 628, in run
    testMethod()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/tests/engine/test_rmq.py", line 141, in test_pause_play
    self.runner.loop.run_until_complete(do_pause_play())
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 92, in run_until_complete
    self._run_once()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 132, in _run_once
    handle._run()
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 201, in run
    ctx.run(self._callback, *self._args)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 159, in step
    step_orig(task, exc)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 159, in step
    step_orig(task, exc)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/nest_asyncio.py", line 159, in step
    step_orig(task, exc)
  [Previous line repeated 2 more times]
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/asyncio/tasks.py", line 249, in __step
    result = coro.send(None)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/tests/engine/test_rmq.py", line 115, in do_pause_play
    calc_node = self.runner.submit(test_processes.WaitProcess)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/runners.py", line 184, in submit
    process_inited = self.instantiate_process(process, *args, **inputs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/runners.py", line 170, in instantiate_process
    return instantiate_process(self, process, *args, **inputs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/utils.py", line 65, in instantiate_process
    process = process_class(runner=runner, inputs=inputs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/plumpy/base/state_machine.py", line 192, in __call__
    inst = super().__call__(*args, **kwargs)
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/aiida/engine/processes/process.py", line 147, in __init__
    communicator=self._runner.communicator
  File "/Users/chrisjsewell/Documents/GitHub/aiida_core_develop/.tox/py37-django/lib/python3.7/site-packages/plumpy/processes.py", line 281, in __init__
    self._future = persistence.SavableFuture(loop=self._loop)
plumpy.exceptions.KilledError: Sorry, you have to go mate
```