### PR TITLE
👌 IMPROVE: Process broadcast subscriber

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - id: pylint
             additional_dependencies: [
                 "pyyaml~=5.1.2", "nest_asyncio~=1.4.0", "aio-pika~=6.6",
-                "aiocontextvars~=0.2.2; python_version<'3.7'", "kiwipy[rmq]~=0.7.1"
+                "aiocontextvars~=0.2.2; python_version<'3.7'", "kiwipy[rmq]~=0.7.4"
             ]
             args:
                 [

--- a/plumpy/communications.py
+++ b/plumpy/communications.py
@@ -62,29 +62,16 @@ def convert_to_comm(callback: 'Subscriber',
     on the given even loop and return a kiwi future representing the future outcome
     of the original method.
 
-    :param loop: the even loop to schedule the callback in
     :param callback: the function to convert
+    :param loop: the even loop to schedule the callback in
     :return: a new callback function that returns a future
     """
     if isinstance(callback, kiwipy.BroadcastFilter):
 
         def _passthrough(*args: Any, **kwargs: Any) -> bool:
-            # pylint: disable=protected-access
             sender = kwargs.get('sender', args[1])
             subject = kwargs.get('subject', args[2])
-            if subject is not None and callback._subject_filters and not any(  # type: ignore[attr-defined]
-                [
-                    check(subject) for check in callback._subject_filters  # type: ignore[attr-defined]
-                ]
-            ):
-                return True
-            if sender is not None and callback._sender_filters and not any(  # type: ignore[attr-defined]
-                [
-                    check(sender) for check in callback._sender_filters  # type: ignore[attr-defined]
-                ]
-            ):
-                return True
-            return False
+            return callback.is_filtered(sender, subject)  # type: ignore[attr-defined]
     else:
 
         def _passthrough(*args: Any, **kwargs: Any) -> bool:  # pylint: disable=unused-argument

--- a/plumpy/communications.py
+++ b/plumpy/communications.py
@@ -68,6 +68,10 @@ def convert_to_comm(callback: 'Subscriber',
     """
     if isinstance(callback, kiwipy.BroadcastFilter):
 
+        # if the broadcast is filtered for this callback,
+        # we don't want to go through the (costly) process
+        # of setting up async tasks and callbacks
+
         def _passthrough(*args: Any, **kwargs: Any) -> bool:
             sender = kwargs.get('sender', args[1])
             subject = kwargs.get('subject', args[2])

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'pyyaml~=5.1.2', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6', 'aiocontextvars~=0.2.2; python_version<"3.7"',
-        'kiwipy[rmq]~=0.7.1'
+        'kiwipy[rmq]~=0.7.4'
     ],
     extras_require={
         'docs': ['sphinx~=3.2.0', 'myst-nb~=0.11.0', 'sphinx-book-theme~=0.0.39', 'ipython~=7.0'],

--- a/test/rmq/test_communicator.py
+++ b/test/rmq/test_communicator.py
@@ -7,7 +7,7 @@ import asyncio
 import shortuuid
 
 import pytest
-from kiwipy import rmq
+from kiwipy import BroadcastFilter, rmq
 
 import plumpy
 from plumpy import communications, process_comms
@@ -77,6 +77,33 @@ class TestLoopCommunicator:
 
         result = await broadcast_future
         assert result == BROADCAST
+
+    @pytest.mark.asyncio
+    async def test_broadcast_filter(self, loop_communicator):
+
+        broadcast_future = plumpy.Future()
+
+        loop = asyncio.get_event_loop()
+
+        def ignore_broadcast(_comm, body, sender, subject, correlation_id):
+            broadcast_future.set_exception(AssertionError('broadcast received'))
+
+        def get_broadcast(_comm, body, sender, subject, correlation_id):
+            broadcast_future.set_result(True)
+
+        loop_communicator.add_broadcast_subscriber(BroadcastFilter(ignore_broadcast, subject='other'))
+        loop_communicator.add_broadcast_subscriber(get_broadcast)
+        loop_communicator.broadcast_send(
+            **{
+                'body': 'present',
+                'sender': 'Martin',
+                'subject': 'sup',
+                'correlation_id': 420
+            }
+        )
+
+        result = await broadcast_future
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_rpc(self, loop_communicator):

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ filterwarnings =
 
 
 [mypy]
+show_error_codes = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 check_untyped_defs = True


### PR DESCRIPTION
Filter out `state_changed` broadcasts, and allow these to pass-through without generating an asynchronous task.

The issue this "fixes" is that, currently, every time a process changes state, this causes a `run_task` asyncio Task to be created for every running process, that then has to be dealt with by the asyncio loop.

As an example, I added `print(len(asyncio.all_tasks(loop=self._loop)))` to the start of `aiida.ProcessLauncher._continue`, and submitting 100 processes (`aiida-sleep calc -n 100 -t 10 --submit`).
The peak number of tasks running rose to over 4000, which I don't imagine is helping the responsiveness of the daemon!

With this PR, the task creation is by-passed and the peak number of tasks decreases to around 150.

Note, this code could be reduced by restructuring `kiwipy.BroadcastFilter` to have a separate `is_filtered` method, I can do that if this looks reasonable to you guys.

I would also note that actually in aiida-core the broadcast subscriber is currently redundant, because in `aiida/cmdline/commands/cmd_process.py` when `verdi process pause/play --all` is called, it queries the database to get all running/paused processes, then makes individual RPC calls, rather than sending a broadcast.


