### PR TITLE
✨ NEW: Add `ProcessLauncher.process_cache`

### DIFF
--- a/plumpy/exceptions.py
+++ b/plumpy/exceptions.py
@@ -33,3 +33,7 @@ class PersistenceError(Exception):
 
 class ClosedError(Exception):
     """Raised when an mutable operation is attempted on a closed process"""
+
+
+class DuplicateProcess(Exception):
+    """Raised when an ProcessLauncher is asked to launch a process it is already running."""

--- a/test/rmq/test_communicator.py
+++ b/test/rmq/test_communicator.py
@@ -7,7 +7,7 @@ import asyncio
 import shortuuid
 
 import pytest
-from kiwipy import rmq
+from kiwipy import RemoteException, rmq
 
 import plumpy
 from plumpy import communications, process_comms
@@ -177,3 +177,15 @@ class TestTaskActions:
         # Let the process run to the end
         result = await async_controller.continue_process(pid)
         assert result, utils.DummyProcessWithOutput.EXPECTED_OUTPUTS
+
+    @pytest.mark.asyncio
+    async def test_duplicate_process(self, loop_communicator, async_controller, persister):
+        loop = asyncio.get_event_loop()
+        launcher = plumpy.ProcessLauncher(loop, persister=persister)
+        loop_communicator.add_task_subscriber(launcher)
+        process = utils.DummyProcessWithOutput()
+        persister.save_checkpoint(process)
+        launcher._process_cache[process.pid] = process
+        assert process.pid in launcher.process_cache
+        with pytest.raises(RemoteException, match='already running'):
+            await async_controller.continue_process(process.pid)


### PR DESCRIPTION
Currently, in aiida-core for a daemon runner:

1. there is no easy way to retrieve the processes running on it (except to search `gc.get_objects()`)
2. running the same process twice is not identified until you hit a `DuplicateSubscriberIdentifier` exception (see https://github.com/aiidateam/aiida-core/issues/4595)

So in this PR I propose to add a cache to the `ProcessLauncher` that keeps a (weak) reference of the process it has launched, and raises a `DuplicateProcess` exception when trying to launch/continue a process that is already running.

I envision potentially also using this in two places:

1. In https://github.com/aiidateam/aiida-core/pull/4769, where I am playing around with returning the number of processes running on each daemon, when calling `verdi daemon status`
2. Together with https://github.com/aiidateam/kiwipy/pull/104, to create a callback that stops all processes currently running when the connection to RMQ is lost. Maybe something like:

```python
def close_callback(sender, exc):
	processes = process_launcher.process_cache.values()
    # we want to immediately stop the process storing anything more to its node,
    # which could conflict with another worker that starts running it
	for process in processes:
        process._enable_persistence = False
    # we could then do seomthing like kill it (knowing that the kill state will no longer be persisted)
    # although this would also send kill signals to its children
    # which may be running on a different worker, and so we would not want to kill
	for process in processes:
        process.kill()  
```