### PR TITLE
🐛 FIX: `Task.cancel` should not set state as EXCEPTED

### DIFF
--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import asyncio
 from enum import Enum
 import sys
 import traceback
@@ -229,7 +230,7 @@ class Running(State):
                     result = self.run_fn(*self.args, **self.kwargs)
                 finally:
                     self._running = False
-            except Interruption:
+            except (Interruption, asyncio.CancelledError):
                 # Let this bubble up to the caller
                 raise
             except Exception:  # pylint: disable=broad-except
@@ -316,7 +317,7 @@ class Waiting(State):
     async def execute(self) -> State:  # type: ignore # pylint: disable=invalid-overridden-method
         try:
             result = await self._waiting_future
-        except Interruption:
+        except (Interruption, asyncio.CancelledError):
             # Deal with the interruption (by raising) but make sure our internal
             # state is back to how it was before the interruption so that we can be
             # re-executed

--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -233,7 +233,7 @@ class Running(State):
             except Interruption:
                 # Let this bubble up to the caller
                 raise
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 # note this re-raise is only required in python<=3.7,
                 # for python>=3.8 asyncio.CancelledError does not inherit from Exception,
                 # so will not be caught below

--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -230,8 +230,13 @@ class Running(State):
                     result = self.run_fn(*self.args, **self.kwargs)
                 finally:
                     self._running = False
-            except (Interruption, asyncio.CancelledError):
+            except Interruption:
                 # Let this bubble up to the caller
+                raise
+            except asyncio.CancelledError:
+                # note this re-raise is only required in python<=3.7,
+                # for python>=3.8 asyncio.CancelledError does not inherit from Exception,
+                # so will not be caught below
                 raise
             except Exception:  # pylint: disable=broad-except
                 excepted = self.create_state(ProcessState.EXCEPTED, *sys.exc_info()[1:])

--- a/plumpy/process_states.py
+++ b/plumpy/process_states.py
@@ -322,7 +322,7 @@ class Waiting(State):
     async def execute(self) -> State:  # type: ignore # pylint: disable=invalid-overridden-method
         try:
             result = await self._waiting_future
-        except (Interruption, asyncio.CancelledError):
+        except Interruption:
             # Deal with the interruption (by raising) but make sure our internal
             # state is back to how it was before the interruption so that we can be
             # re-executed

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -1193,6 +1193,12 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
             except KeyboardInterrupt:  # pylint: disable=try-except-raise
                 raise
+            except futures.CancelledError:
+                # note this re-raise is only required in python<=3.7,
+                # where asyncio.CancelledError == concurrent.futures.CancelledError
+                # it is encountered when the run_task is cancelled
+                # for python>=3.8 asyncio.CancelledError does not inherit from Exception, so will not be caught below
+                raise
             except Exception:  # pylint: disable=broad-except
                 # Overwrite the next state to go to excepted directly
                 next_state = self.create_state(process_states.ProcessState.EXCEPTED, *sys.exc_info()[1:])

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -1193,7 +1193,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
             except KeyboardInterrupt:  # pylint: disable=try-except-raise
                 raise
-            except asyncio.CancelledError:
+            except asyncio.CancelledError:  # pylint: disable=try-except-raise
                 # note this re-raise is only required in python<=3.7,
                 # where asyncio.CancelledError == concurrent.futures.CancelledError
                 # it is encountered when the run_task is cancelled

--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -1193,7 +1193,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
             except KeyboardInterrupt:  # pylint: disable=try-except-raise
                 raise
-            except futures.CancelledError:
+            except asyncio.CancelledError:
                 # note this re-raise is only required in python<=3.7,
                 # where asyncio.CancelledError == concurrent.futures.CancelledError
                 # it is encountered when the run_task is cancelled


### PR DESCRIPTION
See https://github.com/aiidateam/aiida-core/issues/4648#issuecomment-790870664
Currently, stopping the daemon in python 3.7 excepts all processes!