### PR TITLE
‼️ DEPRECATE: `Process.done` method

### DIFF
--- a/plumpy/processes.py
+++ b/plumpy/processes.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 """The main Process module"""
 import abc
+import asyncio
 import contextlib
+import copy
 import enum
 import functools
-import copy
 import logging
-import time
 import sys
-import uuid
-import asyncio
+import time
 from types import TracebackType
 from typing import (
     Any, Awaitable, Callable, cast, Dict, Generator, Hashable, List, Optional, Sequence, Tuple, Type, Union
 )
+import uuid
+import warnings
 
 try:
     from aiocontextvars import ContextVar
@@ -481,9 +482,12 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         return None
 
     def done(self) -> bool:
+        """Return True if the call was successfully killed or finished running.
+
+        .. deprecated:: 0.18.6
+            Use the `has_terminated` method instead
         """
-        Return True if the call was successfully killed or finished running.
-        """
+        warnings.warn('method is deprecated, use `has_terminated` instead', DeprecationWarning)  # pylint: disable=no-member
         return self._state.is_terminal()
 
     # endregion

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -223,7 +223,7 @@ class TestProcess(unittest.TestCase):
         proc = utils.DummyProcessWithOutput()
         proc.execute()
 
-        self.assertTrue(proc.done())
+        self.assertTrue(proc.has_terminated())
         self.assertEqual(proc.state, ProcessState.FINISHED)
         self.assertEqual(proc.outputs, {'default': 5})
 
@@ -331,7 +331,7 @@ class TestProcess(unittest.TestCase):
         proc.execute()
 
         # Check it's done
-        self.assertTrue(proc.done())
+        self.assertTrue(proc.has_terminated())
         self.assertEqual(proc.state, ProcessState.FINISHED)
 
     def test_exc_info(self):
@@ -344,7 +344,7 @@ class TestProcess(unittest.TestCase):
     def test_run_done(self):
         proc = utils.DummyProcess()
         proc.execute()
-        self.assertTrue(proc.done())
+        self.assertTrue(proc.has_terminated())
 
     def test_wait_pause_play_resume(self):
         """
@@ -371,7 +371,7 @@ class TestProcess(unittest.TestCase):
             await proc.future()
 
             # Check it's done
-            self.assertTrue(proc.done())
+            self.assertTrue(proc.has_terminated())
             self.assertEqual(proc.state, ProcessState.FINISHED)
 
         loop.create_task(proc.step_until_terminated())
@@ -412,7 +412,7 @@ class TestProcess(unittest.TestCase):
         loop.create_task(proc.step_until_terminated())
         loop.run_until_complete(async_test())
 
-        self.assertTrue(proc.done())
+        self.assertTrue(proc.has_terminated())
         self.assertEqual(proc.state, ProcessState.FINISHED)
 
     def test_kill_in_run(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -273,7 +273,7 @@ class ProcessSaver(plumpy.ProcessListener, Saver):
 
     def capture(self):
         self._save(self.process)
-        if not self.process.done():
+        if not self.process.has_terminated():
             try:
                 self.process.execute()
             except Exception:


### PR DESCRIPTION
This method is a duplicate of `Process.has_terminated`, and is not used anywhere in plumpy or aiida-core.