### PR TITLE
Dependencies: limit requirement for `frozendict<2.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     keywords='workflow multithreaded rabbitmq',
     install_requires=[
-        'frozendict',
+        'frozendict<2.0',
         'tornado>=4.1, <5.0',
         'pyyaml~=5.1.2',
         'pika>=1.0.0',


### PR DESCRIPTION
Fixes #217 

The `plumpy.utils.AttributeFrozenDict` uses the base implementation of
the `frozendict` library which changed its implementation in v2.0 to not
allow the calling of `__setattr__` causing our implementation to except
in the constructor when trying to set `self._initialized = True`. Since
we dropped the dependency in `plumpy==0.16.0`, we only add this change
as a support release on the `v0.15` series. Since that is the last
version to support Python 3.6 which is not quite yet fully EOL, we want
to support this version a bit longer.