### PR TITLE
Dependencies: relax requirement `nest-asyncio~=1.4`

### DIFF
--- a/plumpy/events.py
+++ b/plumpy/events.py
@@ -53,16 +53,10 @@ def reset_event_loop_policy() -> None:
 
     # pylint: disable=protected-access
     cls = loop.__class__
-    cls._run_once = cls._run_once_orig  # type: ignore
-    cls.run_forever = cls._run_forever_orig  # type: ignore
-    cls.run_until_complete = cls._run_until_complete_orig  # type: ignore
 
     del cls._check_running  # type: ignore
     # typo in Python 3.7 source
     del cls._check_runnung  # type: ignore
-    del cls._run_once_orig  # type: ignore
-    del cls._run_forever_orig  # type: ignore
-    del cls._run_until_complete_orig  # type: ignore
     del cls._nest_patched  # type: ignore
     # pylint: enable=protected-access
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords='workflow multithreaded rabbitmq',
     python_requires='>=3.7',
     install_requires=[
-        'pyyaml~=5.4', 'nest_asyncio~=1.4.0', 'aio-pika~=6.6', 'aiocontextvars~=0.2.2; python_version<"3.7"',
+        'pyyaml~=5.4', 'nest_asyncio~=1.5', 'aio-pika~=6.6', 'aiocontextvars~=0.2.2; python_version<"3.7"',
         'kiwipy[rmq]~=0.7.4'
     ],
     extras_require={


### PR DESCRIPTION
It was pinned to a patch version which was causing conflicts with other
dependencies for `aiida-core`, notably `notebook`.