### PR TITLE
🔧 FIX auto_persist decorator typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ docs = [
     'myst-nb~=0.11.0',
     'sphinx~=3.2.0',
     'sphinx-book-theme~=0.0.39',
+    'importlib-metadata~=4.12.0',
 ]
 pre-commit = [
     'mypy==0.982',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ docs = [
     'sphinx-book-theme~=0.0.39',
 ]
 pre-commit = [
-    'mypy==0.790',
+    'mypy==0.982',
     'pre-commit~=2.2',
     'pylint==2.12.2',
 ]

--- a/src/plumpy/persistence.py
+++ b/src/plumpy/persistence.py
@@ -9,7 +9,7 @@ import inspect
 import os
 import pickle
 from types import MethodType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterable, List, Optional, Set, TypeVar, Union
 
 import yaml
 
@@ -340,9 +340,12 @@ class InMemoryPersister(Persister):
             del self._checkpoints[pid]
 
 
-def auto_persist(*members: str) -> Callable[[Type['Savable']], Type['Savable']]:
+SavableClsType = TypeVar('SavableClsType', bound='Type[Savable]')
 
-    def wrapped(savable: Type['Savable']) -> Type['Savable']:
+
+def auto_persist(*members: str) -> Callable[[SavableClsType], SavableClsType]:
+
+    def wrapped(savable: SavableClsType) -> SavableClsType:
         # pylint: disable=protected-access
         if savable._auto_persist is None:
             savable._auto_persist = set()

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ extras =
     tests
 commands = pytest {posargs}
 
-[testenv:pre-commit]
+[testenv:py{37,38,39}-pre-commit]
 description = Run the style checks and formatting
 extras =
     pre-commit


### PR DESCRIPTION
This is used in aiida-core,
to decorate the `WorkChain` class.
The problem currently is that, because of the decorator typing,
no methods defined on subclasses of `Savable`
are available for static analysers (such as IDE auto-completions).
This change ensures the output of the decorator is the same as the input.