### PR TITLE
`StateMachine`: transition directly to excepted if transition failed 

### DIFF
--- a/src/plumpy/base/state_machine.py
+++ b/src/plumpy/base/state_machine.py
@@ -338,16 +338,14 @@ class StateMachine(metaclass=StateMachineMeta):
             self._transition_failing = False
             self._transitioning = False
 
-    @staticmethod
-    def transition_failed(
-        initial_state: Hashable, final_state: Hashable, exception: Exception, trace: TracebackType
+    def transition_failed(  # pylint: disable=no-self-use
+        self, initial_state: Hashable, final_state: Hashable, exception: Exception, trace: TracebackType
     ) -> None:
-        """
-        Called when a state transitions fails.  This method can be overwritten
-        to change the default behaviour which is to raise the exception.
+        """Called when a state transitions fails.
 
-        :param exception: The transition failed exception
+        This method can be overwritten to change the default behaviour which is to raise the exception.
 
+        :param exception: The transition failed exception.
         """
         raise exception.with_traceback(trace)
 

--- a/src/plumpy/base/state_machine.py
+++ b/src/plumpy/base/state_machine.py
@@ -315,7 +315,10 @@ class StateMachine(metaclass=StateMachineMeta):
             # Make sure we have a state instance
             new_state = self._create_state_instance(new_state, *args, **kwargs)
             label = new_state.LABEL
-            self._exit_current_state(new_state)
+
+            # If the previous transition failed, do not try to exit it but go straight to next state
+            if not self._transition_failing:
+                self._exit_current_state(new_state)
 
             try:
                 self._enter_next_state(new_state)

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -487,6 +487,14 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         return None
 
+    @property
+    def is_excepted(self) -> bool:
+        """Return whether the process excepted.
+
+        :return: boolean, True if the process is in ``EXCEPTED`` state.
+        """
+        return self.state == process_states.ProcessState.EXCEPTED
+
     def done(self) -> bool:
         """Return True if the call was successfully killed or finished running.
 

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -828,6 +828,13 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         """Entering the EXCEPTED state."""
         exception = exc_info[1]
         exception.__traceback__ = exc_info[2]
+
+        # It is possible that we already got into a finished state and the future result was set, in which case, we
+        # should reset it before setting the exception or else ``asyncio`` will raise an exception.
+        future = self.future()
+
+        if future.done():
+            self._future = persistence.SavableFuture(loop=self._loop)
         self.future().set_exception(exception)
 
     @super_check

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -978,8 +978,8 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
     # region State related methods
 
-    def transition_excepted(
-        self, _initial_state: Any, final_state: process_states.ProcessState, exception: Exception, trace: TracebackType
+    def transition_failed(
+        self, initial_state: Hashable, final_state: Hashable, exception: Exception, trace: TracebackType
     ) -> None:
         # If we are creating, then reraise instead of failing.
         if final_state == process_states.ProcessState.CREATED:

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -499,6 +499,8 @@ class TestProcess(unittest.TestCase):
         with self.assertRaises(ValueError):
             proc.execute()
 
+        assert proc.is_excepted
+
     def test_missing_output(self):
         proc = utils.MissingOutputProcess()
 
@@ -507,7 +509,7 @@ class TestProcess(unittest.TestCase):
 
         proc.execute()
 
-        self.assertFalse(proc.successful())
+        self.assertFalse(proc.is_successful)
 
     def test_unsuccessful_result(self):
         ERROR_CODE = 256

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -242,10 +242,9 @@ class TestProcess(unittest.TestCase):
                 proc.execute()
 
     def test_forget_to_call_parent_kill(self):
-        with self.assertRaises(AssertionError):
-            proc = ForgetToCallParent('kill')
-            proc.kill()
-            proc.execute()
+        proc = ForgetToCallParent('kill')
+        proc.kill()
+        assert proc.is_excepted
 
     def test_pid(self):
         # Test auto generation of pid

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -654,6 +654,40 @@ class TestProcess(unittest.TestCase):
         with self.assertRaises(plumpy.ClosedError):
             proc.execute()
 
+    def test_exception_during_on_entered(self):
+        """Test that an exception raised during ``on_entered`` will cause the process to be excepted."""
+
+        class RaisingProcess(Process):
+
+            def on_entered(self, from_state):
+                if from_state is not None and from_state.label == ProcessState.RUNNING:
+                    raise RuntimeError('exception during on_entered')
+                super().on_entered(from_state)
+
+        process = RaisingProcess()
+
+        with self.assertRaises(RuntimeError):
+            process.execute()
+
+        assert not process.is_successful
+        assert process.is_excepted
+        assert str(process.exception()) == 'exception during on_entered'
+
+    def test_exception_during_run(self):
+
+        class RaisingProcess(Process):
+
+            def run(self):
+                raise RuntimeError('exception during run')
+
+        process = RaisingProcess()
+
+        with self.assertRaises(RuntimeError):
+            process.execute()
+
+        assert process.is_excepted
+        assert str(process.exception()) == 'exception during run'
+
 
 @plumpy.auto_persist('steps_ran')
 class SavePauseProc(plumpy.Process):


### PR DESCRIPTION
Fixes #219 

Before, if a state transition failed a transition to the excepted state
would be initiated. However, if the original failure came from a method
that would be called in all state transitions, i.e. also when
transitioning to the excepted, it would be guaranteed to be hit again.
In the second transition failure, the exception would simply be raised
again and bubble up.

In the case of a transition failure and so `self._transition_failed` is
set to `True`, the current state should not be explicitly exited but one
should transition straight to the excepted state.

This change now effectively allows the state machine to transition from
a `FINISHED` state to the `EXCEPTED` state. A process could transition
to the `FINISHED` state and on exiting the `FINISHED` state, an
exception could be raised. In this case the result of the future would
already be set, so the `on_except` method needs to check for this, and
when set, first reset the future before setting the exception.

This PR also has two other commits, one with a small feature and a small bug fix.