### PR TITLE
Dependencies: Add lower limit for patch version of `nest-asyncio`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = '>=3.7'
 dependencies = [
     'aio-pika~=6.6',
     'kiwipy[rmq]~=0.7.4',
-    'nest_asyncio~=1.5',
+    'nest_asyncio~=1.5,>=1.5.1',
     'pyyaml~=5.4',
 ]
 


### PR DESCRIPTION
Fixes #236 

The package breaks for `nest-asyncio==1.5.0` so the requirement is updated to add the lower bound `nest-asyncio>=1.5.1`.