### PR TITLE
Dependencies: Update requirement `pyyaml~=6.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 keywords = ['workflow', 'multithreaded', 'rabbitmq']
 requires-python = '>=3.7'
 dependencies = [
-    'kiwipy[rmq]~=0.8.2',
+    'kiwipy[rmq]~=0.8.3',
     'nest_asyncio~=1.5,>=1.5.1',
-    'pyyaml~=5.4',
+    'pyyaml~=6.0',
 ]
 
 [project.urls]
@@ -42,7 +42,7 @@ Documentation = 'https://plumpy.readthedocs.io'
 docs = [
     'ipython~=7.0',
     'jinja2==2.11.3',
-    'kiwipy[docs]~=0.8.2',
+    'kiwipy[docs]~=0.8.3',
     'markupsafe==2.0.1',
     'myst-nb~=0.11.0',
     'sphinx~=3.2.0',


### PR DESCRIPTION
This latest version adds official support for Python 3.11. Also need to update `kiwipy` to `~=0.8.3` since older versions pin the `pyyaml` version to `~=5.0`.