### PR TITLE
Dependencies: Update the myst-nb and sphinx requirements 

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,9 +55,9 @@ myst_substitutions = {
     'rabbitmq': '[RabbitMQ](https://www.rabbitmq.com/)',
     'kiwipy': '[kiwipy](https://kiwipy.readthedocs.io)'
 }
-jupyter_execute_notebooks = 'cache'
-execution_show_tb = 'READTHEDOCS' in os.environ
-execution_timeout = 60
+nb_execution_mode = 'cache'
+nb_execution_show_tb = 'READTHEDOCS' in os.environ
+nb_execution_timeout = 60
 
 # Warnings to ignore when using the -n (nitpicky) option
 # We should ignore any python built-in exception, for instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ docs = [
     'ipython~=7.0',
     'jinja2==2.11.3',
     'markupsafe==2.0.1',
-    'myst-nb~=0.11.0',
-    'sphinx~=3.2.0',
+    'myst-nb~=0.15.0',
+    'sphinx~=3.5',
     'sphinx-book-theme~=0.0.39',
 ]
 pre-commit = [


### PR DESCRIPTION
The docs build was failing. Updating `myst-nb` solves the problem. It is
only updated to `v0.15.0` and not more recent as that is the last
version to support `sphinx~=3.5` and more recent versions of Sphinx
raise warnings with the auto API docs.