### PR TITLE
Workchains: Accept but deprecate conditional predicates returning `None`

### DIFF
--- a/src/plumpy/workchains.py
+++ b/src/plumpy/workchains.py
@@ -390,6 +390,15 @@ class _Conditional:
     def is_true(self, workflow: 'WorkChain') -> bool:
         result = self._predicate(workflow)
 
+        if result is None:
+            import warnings
+            warnings.warn(
+                f'The conditional predicate `{self._predicate.__name__}` returned `None` but it should return a bool. '
+                'The behavior is deprecated and will soon start raising an exception, please return ``False`` instead.',
+                UserWarning
+            )
+            return False
+
         if not isinstance(result, bool):
             raise TypeError(f'The conditional predicate `{self._predicate.__name__}` did not return a boolean')
 

--- a/test/test_workchains.py
+++ b/test/test_workchains.py
@@ -621,11 +621,20 @@ class TestImmutableInputWorkchain(unittest.TestCase):
 
 
 @pytest.mark.parametrize('construct', (if_, while_))
-def test_conditional_return_type(construct):
-    """Test that a conditional passed to the ``if_`` and ``while_`` functions that does not return a ``bool`` raises."""
+def test_conditional_return_type(construct, caplog):
+    """Test that a conditional passed to the ``if_`` and ``while_`` functions that does not return a ``bool`` raises.
+
+    For now ``None`` is still accepted and is interpreted as ``False`` but it emits a deprecation warning.
+    """
 
     def invalid_conditional(self):
         return 'true'
 
     with pytest.raises(TypeError, match='The conditional predicate `invalid_conditional` did not return a boolean'):
         construct(invalid_conditional)[0].is_true(None)
+
+    def deprecated_conditional(self):
+        return None
+
+    with pytest.warns(UserWarning):
+        construct(deprecated_conditional)[0].is_true(None)


### PR DESCRIPTION
In 800bcf154c0ea0d4576636b95d2ad2285adec266, the behavior of predicates passed to `_Conditional` instances was changed to raise if anything but a boolean was returned. This was to catch cases where users would return non-boolean values by accident, which would anyway would most likely to broken behavior of the workchain.

However, quite a number of existing implementations used to do something like the following in a predicate

    def conditional_predicate(self):
        if some_condition is True:
             return True

In the case that `some_condition` was not equal to `True`, the predicate would return `None` which would be evaluated as "falsy" and so would function as if `False` had been returned.

In order to not break all implemenations using this behavior, `None` is still accepted and automatically converted to `False`. A `UserWarning` is emitted to warn that the behavior is deprecated. This is used in favor of a `DeprecationWarning` since those are not shown by default, which means the majority of users wouldn't see the deprecation warning.