### PR TITLE
Workchains: Turn exception into warning for incorrect return type in conditional predicate

### DIFF
--- a/src/plumpy/workchains.py
+++ b/src/plumpy/workchains.py
@@ -390,17 +390,13 @@ class _Conditional:
     def is_true(self, workflow: 'WorkChain') -> bool:
         result = self._predicate(workflow)
 
-        if result is None:
+        if not isinstance(result, bool):
             import warnings
             warnings.warn(
-                f'The conditional predicate `{self._predicate.__name__}` returned `None` but it should return a bool. '
-                'The behavior is deprecated and will soon start raising an exception, please return ``False`` instead.',
-                UserWarning
+                f'The conditional predicate `{self._predicate.__name__}` returned `{result}` but it should return a '
+                'bool. The behavior is deprecated and will soon start raising an exception, please return ``False`` '
+                'instead.', UserWarning
             )
-            return False
-
-        if not isinstance(result, bool):
-            raise TypeError(f'The conditional predicate `{self._predicate.__name__}` did not return a boolean')
 
         return result
 

--- a/test/test_workchains.py
+++ b/test/test_workchains.py
@@ -622,15 +622,12 @@ class TestImmutableInputWorkchain(unittest.TestCase):
 
 @pytest.mark.parametrize('construct', (if_, while_))
 def test_conditional_return_type(construct, caplog):
-    """Test that a conditional passed to the ``if_`` and ``while_`` functions that does not return a ``bool`` raises.
-
-    For now ``None`` is still accepted and is interpreted as ``False`` but it emits a deprecation warning.
-    """
+    """Test that a conditional passed to the ``if_`` and ``while_`` functions that does not return a ``bool`` warns."""
 
     def invalid_conditional(self):
         return 'true'
 
-    with pytest.raises(TypeError, match='The conditional predicate `invalid_conditional` did not return a boolean'):
+    with pytest.warns(UserWarning):
         construct(invalid_conditional)[0].is_true(None)
 
     def deprecated_conditional(self):


### PR DESCRIPTION
Fixes #262 

In f47627adf0dece414c26254515f53fb7414bb3bf, the recently added check on the return type of a conditional predicate was updated slightly to only emit a warning when `None` would be returned instead of raising a `TypeError`. This was done because there quite a number of workchains that unwittingly were relying on this behavior and with the change added in 800bcf154c0ea0d4576636b95d2ad2285adec266 would break all of these.

Since then, it was discovered that the exception for `None` may still not be enough as it turns out that there are also quite a number of workchains that use objects that behave like booleans, but are not actually instances of the built-in `bool` base type. Examples, are `numpy.bool` as well as `aiida.orm.Bool`. Since here the behavior of the predicate would be as expected, breaking the existing workflow is actually not desirable.

To be on the safe side, we remove the raising of the exception and for now merely emit the warning, in order to give a proper window for existing code to adapt. This approach is chosen in favor of an attempt to _also_ add an exception for return values that are bool-like, because it is not clear that we can be sure we won't miss yet another edge-case.