### PR TITLE
Workchains: Turn exception into warning for incorrect return type in conditional predicates

### DIFF
--- a/src/plumpy/workchains.py
+++ b/src/plumpy/workchains.py
@@ -390,17 +390,13 @@ class _Conditional:
     def is_true(self, workflow: 'WorkChain') -> bool:
         result = self._predicate(workflow)
 
-        if result is None:
+        if not hasattr(result, '__bool__'):
             import warnings
             warnings.warn(
-                f'The conditional predicate `{self._predicate.__name__}` returned `None` but it should return a bool. '
-                'The behavior is deprecated and will soon start raising an exception, please return ``False`` instead.',
-                UserWarning
+                f'The conditional predicate `{self._predicate.__name__}` returned `{result}` which is not boolean-like.'
+                ' The return value should be `True` or `False` or implement the `__bool__` method. This behavior is '
+                'deprecated and will soon start raising an exception.', UserWarning
             )
-            return False
-
-        if not isinstance(result, bool):
-            raise TypeError(f'The conditional predicate `{self._predicate.__name__}` did not return a boolean')
 
         return result
 


### PR DESCRIPTION
Fixes #262 

In f47627adf0dece414c26254515f53fb7414bb3bf, the recently added check on the return type of a conditional predicate was updated slightly to only emit a warning when `None` would be returned instead of raising a `TypeError`. This was done because there quite a number of workchains that unwittingly were relying on this behavior and with the change added in 800bcf154c0ea0d4576636b95d2ad2285adec266 would break all of these.

Since then, it was discovered that the exception for `None` may still not be enough as it turns out that there are also quite a number of workchains that use objects that behave like booleans, but are not actually instances of the built-in `bool` base type. Examples, are `numpy.bool` as well as `aiida.orm.Bool`. Since here the behavior of the predicate would be as expected, breaking the existing workflow is actually not desirable.

Therefore, the requirement on the return type is relaxed slightly further to any type that implements the `__bool__` method. This includes `None`, but also types like `numpy.bool` and `aiida.orm.Bool` which are often used in the workchain logic by AiiDA code. There might still be edge cases where users may (accidentally) return a type from a function that does implement `__bool__` but whose evaluated value is not what the user intended, but that risk is preferable then forcing users to cast bool-like instances explicit to a `bool`.