### PR TITLE
Docs: Update ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+    os: ubuntu-22.04
+    tools:
+        python: '3.8'
+
 python:
-    version: 3.8
     install:
         - method: pip
           path: .


### PR DESCRIPTION
Add the new required `build.os` key and fix it to Ubuntu 22.04