### PR TITLE
plumpy.ProcessListener made persistent support/0.21.x

### DIFF
--- a/src/plumpy/base/utils.py
+++ b/src/plumpy/base/utils.py
@@ -16,7 +16,7 @@ def super_check(wrapped: Callable[..., Any]) -> Callable[..., Any]:
         wrapped(self, *args, **kwargs)
         self._called -= 1
 
-    #the following is to show the correct name later in the call_with_super_check error message
+    # Forward wrapped function name to the decorator to show the correct name in the ``call_with_super_check``
     wrapper.__name__ = wrapped.__name__
     return wrapper
 

--- a/src/plumpy/base/utils.py
+++ b/src/plumpy/base/utils.py
@@ -16,6 +16,8 @@ def super_check(wrapped: Callable[..., Any]) -> Callable[..., Any]:
         wrapped(self, *args, **kwargs)
         self._called -= 1
 
+    #the following is to show the correct name later in the call_with_super_check error message
+    wrapper.__name__ = wrapped.__name__
     return wrapper
 
 

--- a/src/plumpy/event_helper.py
+++ b/src/plumpy/event_helper.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Set, Type
+
+from . import persistence
+
+if TYPE_CHECKING:
+    from .process_listener import ProcessListener  # pylint: disable=cyclic-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@persistence.auto_persist('_listeners', '_listener_type')
+class EventHelper(persistence.Savable):
+
+    def __init__(self, listener_type: 'Type[ProcessListener]'):
+        assert listener_type is not None, 'Must provide valid listener type'
+
+        self._listener_type = listener_type
+        self._listeners: 'Set[ProcessListener]' = set()
+
+    def add_listener(self, listener: 'ProcessListener') -> None:
+        assert isinstance(listener, self._listener_type), 'Listener is not of right type'
+        self._listeners.add(listener)
+
+    def remove_listener(self, listener: 'ProcessListener') -> None:
+        self._listeners.discard(listener)
+
+    def remove_all_listeners(self) -> None:
+        self._listeners.clear()
+
+    @property
+    def listeners(self) -> 'Set[ProcessListener]':
+        return self._listeners
+
+    def fire_event(self, event_function: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Call an event method on all listeners.
+
+        :param event_function: the method of the ProcessListener
+        :param args: arguments to pass to the method
+        :param kwargs: keyword arguments to pass to the method
+
+        """
+        if event_function is None:
+            raise ValueError('Must provide valid event method')
+
+        # Make a copy of the list for iteration just in case it changes in a callback
+        for listener in list(self.listeners):
+            try:
+                getattr(listener, event_function.__name__)(*args, **kwargs)
+            except Exception as exception:  # pylint: disable=broad-except
+                _LOGGER.error("Listener '%s' produced an exception:\n%s", listener, exception)

--- a/src/plumpy/event_helper.py
+++ b/src/plumpy/event_helper.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from . import persistence
 
 if TYPE_CHECKING:
+    from typing import Set, Type
     from .process_listener import ProcessListener  # pylint: disable=cyclic-import
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/plumpy/event_helper.py
+++ b/src/plumpy/event_helper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Set, Type
+from typing import TYPE_CHECKING, Any, Callable
 
 from . import persistence
 

--- a/src/plumpy/event_helper.py
+++ b/src/plumpy/event_helper.py
@@ -6,6 +6,7 @@ from . import persistence
 
 if TYPE_CHECKING:
     from typing import Set, Type
+
     from .process_listener import ProcessListener  # pylint: disable=cyclic-import
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -42,6 +42,7 @@ from . import events, exceptions, futures, persistence, ports, process_comms, pr
 from .base import state_machine
 from .base.state_machine import StateEntryFailed, StateMachine, TransitionFailed, event
 from .base.utils import call_with_super_check, super_check
+from .event_helper import EventHelper
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
 from .utils import PID_TYPE, SAVED_STATE_TYPE, protected
@@ -91,7 +92,9 @@ def ensure_not_closed(func: Callable[..., Any]) -> Callable[..., Any]:
     return func_wrapper
 
 
-@persistence.auto_persist('_pid', '_creation_time', '_future', '_paused', '_status', '_pre_paused_status')
+@persistence.auto_persist(
+    '_pid', '_creation_time', '_future', '_paused', '_status', '_pre_paused_status', '_event_helper'
+)
 class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMeta):
     """
     The Process class is the base for any unit of work in plumpy.
@@ -289,7 +292,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         # Runtime variables
         self._future = persistence.SavableFuture(loop=self._loop)
-        self.__event_helper = utils.EventHelper(ProcessListener)
+        self._event_helper = EventHelper(ProcessListener)
         self._logger = logger
         self._communicator = communicator
 
@@ -612,7 +615,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         # Runtime variables, set initial states
         self._future = persistence.SavableFuture()
-        self.__event_helper = utils.EventHelper(ProcessListener)
+        self._event_helper = EventHelper(ProcessListener)
         self._logger = None
         self._communicator = None
 
@@ -661,11 +664,11 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         """
         assert (listener != self), 'Cannot listen to yourself!'
-        self.__event_helper.add_listener(listener)
+        self._event_helper.add_listener(listener)
 
     def remove_process_listener(self, listener: ProcessListener) -> None:
         """Remove a process listener from the process."""
-        self.__event_helper.remove_listener(listener)
+        self._event_helper.remove_listener(listener)
 
     @protected
     def set_logger(self, logger: logging.Logger) -> None:
@@ -778,7 +781,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         """Output is about to be emitted."""
 
     def on_output_emitted(self, output_port: str, value: Any, dynamic: bool) -> None:
-        self.__event_helper.fire_event(ProcessListener.on_output_emitted, self, output_port, value, dynamic)
+        self._event_helper.fire_event(ProcessListener.on_output_emitted, self, output_port, value, dynamic)
 
     @super_check
     def on_wait(self, awaitables: Sequence[Awaitable]) -> None:
@@ -891,7 +894,7 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
             self._closed = True
 
     def _fire_event(self, evt: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
-        self.__event_helper.fire_event(evt, self, *args, **kwargs)
+        self._event_helper.fire_event(evt, self, *args, **kwargs)
 
     # endregion
 

--- a/src/plumpy/utils.py
+++ b/src/plumpy/utils.py
@@ -27,47 +27,6 @@ SAVED_STATE_TYPE = MutableMapping[str, Any]  # pylint: disable=invalid-name
 PID_TYPE = Hashable  # pylint: disable=invalid-name
 
 
-class EventHelper:
-
-    def __init__(self, listener_type: 'Type[ProcessListener]'):
-        assert listener_type is not None, 'Must provide valid listener type'
-
-        self._listener_type = listener_type
-        self._listeners: 'Set[ProcessListener]' = set()
-
-    def add_listener(self, listener: 'ProcessListener') -> None:
-        assert isinstance(listener, self._listener_type), 'Listener is not of right type'
-        self._listeners.add(listener)
-
-    def remove_listener(self, listener: 'ProcessListener') -> None:
-        self._listeners.discard(listener)
-
-    def remove_all_listeners(self) -> None:
-        self._listeners.clear()
-
-    @property
-    def listeners(self) -> 'Set[ProcessListener]':
-        return self._listeners
-
-    def fire_event(self, event_function: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
-        """Call an event method on all listeners.
-
-        :param event_function: the method of the ProcessListener
-        :param args: arguments to pass to the method
-        :param kwargs: keyword arguments to pass to the method
-
-        """
-        if event_function is None:
-            raise ValueError('Must provide valid event method')
-
-        # Make a copy of the list for iteration just in case it changes in a callback
-        for listener in list(self.listeners):
-            try:
-                getattr(listener, event_function.__name__)(*args, **kwargs)
-            except Exception as exception:  # pylint: disable=broad-except
-                _LOGGER.error("Listener '%s' produced an exception:\n%s", listener, exception)
-
-
 class Frozendict(Mapping):
     """
     An immutable wrapper around dictionaries that implements the complete :py:class:`collections.abc.Mapping`

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -800,9 +800,8 @@ class TestProcessSaving(unittest.TestCase):
             # Check that it is a copy
             self.assertIsNot(outputs, bundle.get(BundleKeys.OUTPUTS, {}))
             # Check the contents are the same
-            #we remove the ProcessSaver instance that is an object used only for testing
+            # Remove the ``ProcessSaver`` instance that is only used for testing
             utils.compare_dictionaries(None, None, outputs, bundle.get(BundleKeys.OUTPUTS, {}), exclude={'_listeners'})
-            #self.assertDictEqual(outputs, bundle.get(BundleKeys.OUTPUTS, {}))
 
         self.assertIsNot(proc.outputs, saver.snapshots[-1].get(BundleKeys.OUTPUTS, {}))
 
@@ -877,7 +876,6 @@ class TestProcessSaving(unittest.TestCase):
         bundle2 = plumpy.Bundle(proc2)
 
         self.assertEqual(proc1.pid, proc2.pid)
-        #self.assertDictEqual(bundle1, bundle2)
         utils.compare_dictionaries(None, None, bundle1, bundle2, exclude={'_listeners'})
 
 

--- a/test/test_processes.py
+++ b/test/test_processes.py
@@ -800,7 +800,9 @@ class TestProcessSaving(unittest.TestCase):
             # Check that it is a copy
             self.assertIsNot(outputs, bundle.get(BundleKeys.OUTPUTS, {}))
             # Check the contents are the same
-            self.assertDictEqual(outputs, bundle.get(BundleKeys.OUTPUTS, {}))
+            #we remove the ProcessSaver instance that is an object used only for testing
+            utils.compare_dictionaries(None, None, outputs, bundle.get(BundleKeys.OUTPUTS, {}), exclude={'_listeners'})
+            #self.assertDictEqual(outputs, bundle.get(BundleKeys.OUTPUTS, {}))
 
         self.assertIsNot(proc.outputs, saver.snapshots[-1].get(BundleKeys.OUTPUTS, {}))
 
@@ -875,7 +877,8 @@ class TestProcessSaving(unittest.TestCase):
         bundle2 = plumpy.Bundle(proc2)
 
         self.assertEqual(proc1.pid, proc2.pid)
-        self.assertDictEqual(bundle1, bundle2)
+        #self.assertDictEqual(bundle1, bundle2)
+        utils.compare_dictionaries(None, None, bundle1, bundle2, exclude={'_listeners'})
 
 
 class TestProcessNamespace(unittest.TestCase):

--- a/test/test_workchains.py
+++ b/test/test_workchains.py
@@ -283,6 +283,49 @@ class TestWorkchain(unittest.TestCase):
             if step not in ['isA', 's2', 'isB', 's3']:
                 self.assertTrue(finished, f'Step {step} was not called by workflow')
 
+    def test_listener_persistence(self):
+        persister = plumpy.InMemoryPersister()
+        process_finished_count = 0
+
+        class TestListener(plumpy.ProcessListener):
+
+            def on_process_finished(self, process, output):
+                nonlocal process_finished_count
+                process_finished_count += 1
+
+        class SimpleWorkChain(plumpy.WorkChain):
+
+            @classmethod
+            def define(cls, spec):
+                super().define(spec)
+                spec.outline(
+                    cls.step1,
+                    cls.step2,
+                )
+
+            def step1(self):
+                print('step1')
+                persister.save_checkpoint(self, 'step1')
+
+            def step2(self):
+                print('step2')
+                persister.save_checkpoint(self, 'step2')
+
+        # add SimpleWorkChain and TestListener to this module global namespace, so they can be reloaded from checkpoint
+        globals()['SimpleWorkChain'] = SimpleWorkChain
+        globals()['TestListener'] = TestListener
+
+        workchain = SimpleWorkChain()
+        workchain.add_process_listener(TestListener())
+        output = workchain.execute()
+
+        self.assertEqual(process_finished_count, 1)
+
+        print('reload persister checkpoint:')
+        workchain_checkpoint = persister.load_checkpoint(workchain.pid, 'step1').unbundle()
+        workchain_checkpoint.execute()
+        self.assertEqual(process_finished_count, 2)
+
     def test_return_in_outline(self):
 
         class WcWithReturn(WorkChain):

--- a/test/test_workchains.py
+++ b/test/test_workchains.py
@@ -304,11 +304,9 @@ class TestWorkchain(unittest.TestCase):
                 )
 
             def step1(self):
-                print('step1')
                 persister.save_checkpoint(self, 'step1')
 
             def step2(self):
-                print('step2')
                 persister.save_checkpoint(self, 'step2')
 
         # add SimpleWorkChain and TestListener to this module global namespace, so they can be reloaded from checkpoint
@@ -321,7 +319,6 @@ class TestWorkchain(unittest.TestCase):
 
         self.assertEqual(process_finished_count, 1)
 
-        print('reload persister checkpoint:')
         workchain_checkpoint = persister.load_checkpoint(workchain.pid, 'step1').unbundle()
         workchain_checkpoint.execute()
         self.assertEqual(process_finished_count, 2)


### PR DESCRIPTION
Fixes https://github.com/aiidateam/plumpy/issues/273

We implement the persistence of ProcessListener by deriving the class ProcessListener and EventHelper from persistence.Savable. The class EventHelper is moved to a new file because of a circular import with utils and persistence

There was a circular reference issue in the test listener that was storing a reference to the process inside it, making its serialization impossible. To fix the tests an ugly hack was used: storing the reference to the process outside the class in a global dict using id as keys. Some more ugly hacks are needed to check correctly the equality of two processes. We must ignore the fact that the instances if the listener are different.

We call del on dict items of the ProcessListener's global implemented in the test suite to clean the golbal variables

addressed issues in https://github.com/aiidateam/plumpy/pull/274