### PR TITLE
Make `Waiting.resume()` idempotent (#285)

### DIFF
--- a/src/plumpy/process_states.py
+++ b/src/plumpy/process_states.py
@@ -336,6 +336,10 @@ class Waiting(State):
 
     def resume(self, value: Any = NULL) -> None:
         assert self._waiting_future is not None, 'Not yet waiting'
+
+        if self._waiting_future.done():
+            return
+
         self._waiting_future.set_result(value)
 
 

--- a/test/rmq/docker-compose.yml
+++ b/test/rmq/docker-compose.yml
@@ -12,16 +12,15 @@
 version: '3.4'
 
 services:
-
   rabbit:
-    image: rabbitmq:3.8.3-management
-    container_name: plumpy-rmq
+    image: rabbitmq:3-management-alpine
+    container_name: plumpy_rmq
+    ports:
+        - 5672:5672
+        - 15672:15672
     environment:
         RABBITMQ_DEFAULT_USER: guest
         RABBITMQ_DEFAULT_PASS: guest
-    ports:
-      - '5672:5672'
-      - '15672:15672'
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 30s


### PR DESCRIPTION
Calling `Waiting.resume()` when it had already been resumed would raise an exception. Here, the method is made idempotent by checking first whether the future has already been resolved. This fix ensures the behavior matches the behavior of the other state transitions: calling `play` on an already running process and calling `pause` on an already paused process isn't rising any error.