### PR TITLE
Remove dependency of typing-extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,9 @@ classifiers = [
 keywords = ['workflow', 'multithreaded', 'rabbitmq']
 requires-python = '>=3.8'
 dependencies = [
-    'kiwipy[rmq]~=0.8.3',
+    'kiwipy[rmq]~=0.8.5',
     'nest_asyncio~=1.5,>=1.5.1',
     'pyyaml~=6.0',
-    # XXX: workaround for https://github.com/mosquito/aio-pika/issues/649
-    'typing-extensions~=4.12',
 ]
 
 [project.urls]


### PR DESCRIPTION
Since kiwipy pinning the upbound version of aio-pika to 9.4.0 to not include the bug of typing-extentions import error of https://github.com/mosquito/aio-pika/issues/649.