### PR TITLE
Make rpc callback exception more explicit and wind up to show more infos

### DIFF
--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -1023,8 +1023,8 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
                 try:
                     result = callback(*args, **kwargs)
                 except Exception as exc:
-                    import traceback
                     import inspect
+                    import traceback
 
                     # Get traceback as a string
                     tb_str = ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))


### PR DESCRIPTION
Combine with https://github.com/aiidateam/aiida-core/pull/6671, it improves the debug workflow of daemon errors with RMQ.