### PR TITLE
Handle Uuid FullLoader with yaml de/serializer

### DIFF
--- a/src/plumpy/persistence.py
+++ b/src/plumpy/persistence.py
@@ -8,6 +8,7 @@ import fnmatch
 import inspect
 import os
 import pickle
+import uuid
 from types import MethodType
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, Iterable, List, Optional, Set, TypeVar, Union
 
@@ -33,6 +34,19 @@ PersistedCheckpoint = collections.namedtuple('PersistedCheckpoint', ['pid', 'tag
 
 if TYPE_CHECKING:
     from .processes import Process
+
+
+def uuid_representer(dumper, data):  # type: ignore
+    return dumper.represent_scalar('!uuid', str(data))
+
+
+def uuid_constructor(loader, node):  # type: ignore
+    value = loader.construct_scalar(node)
+    return uuid.UUID(value)
+
+
+yaml.add_representer(uuid.UUID, uuid_representer)
+yaml.add_constructor('!uuid', uuid_constructor)
 
 
 class Bundle(dict):

--- a/tests/rmq/test_communicator.py
+++ b/tests/rmq/test_communicator.py
@@ -33,12 +33,16 @@ def loop_communicator():
     message_exchange = f'{__file__}.{shortuuid.uuid()}'
     task_exchange = f'{__file__}.{shortuuid.uuid()}'
     task_queue = f'{__file__}.{shortuuid.uuid()}'
+    encoder = functools.partial(yaml.dump, encoding='utf-8')
+    decoder = functools.partial(yaml.load, Loader=yaml.FullLoader)
 
     thread_communicator = rmq.RmqThreadCommunicator.connect(
         connection_params={'url': 'amqp://guest:guest@localhost:5672/'},
         message_exchange=message_exchange,
         task_exchange=task_exchange,
         task_queue=task_queue,
+        encoder=encoder,
+        decoder=decoder,
     )
 
     loop = asyncio.get_event_loop()

--- a/tests/rmq/test_communicator.py
+++ b/tests/rmq/test_communicator.py
@@ -39,7 +39,6 @@ def loop_communicator():
         message_exchange=message_exchange,
         task_exchange=task_exchange,
         task_queue=task_queue,
-        decoder=functools.partial(yaml.load, Loader=yaml.Loader),
     )
 
     loop = asyncio.get_event_loop()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -90,6 +90,6 @@ class TestBundle(unittest.TestCase):
         bundle = plumpy.Bundle(Save1())
         represent = yaml.dump({'bundle': bundle})
 
-        bundle_loaded = yaml.load(represent, Loader=yaml.Loader)['bundle']
+        bundle_loaded = yaml.load(represent, Loader=yaml.UnsafeLoader)['bundle']
         self.assertIsInstance(bundle_loaded, plumpy.Bundle)
         self.assertDictEqual(bundle_loaded, Save1().save())


### PR DESCRIPTION
In https://github.com/aiidateam/plumpy/pull/221, the yaml loaders are changed to UnsafeLoader to solve the problem after new (at that time it is new, it has been three years now) PyYAML, by default it won't de/se customize type. 

The changes in https://github.com/aiidateam/plumpy/pull/221 touched two things, one was the deserializer for bundle type which the change is needed, as detail discussion in https://github.com/aiidateam/aiida-core/issues/3709 where issue was originally manifested. 

But the change of using `UnsafeLoader` also made for the kiwipy message decoder, which is not necessary. The reason that the `rmq.test_communications:test_launch_nowait` test was hanging is that the response ack message from channel is a PID which has type `uuid.UUID`. It is not a basic type that covered by yaml decoder. 

The more fine tuning change I think should be just adding the UUID representer and constructor explicitly. 

Here I also explicitly use `UnsafeLoader` instead of `Loader` which are the same, but Loader is for backward compatibility and `UnsafeLoader` is the new API and give the information that it is unsafe operation. 

@superstar54 @giovannipizzi, for the workgraph the `unsafe_deserializer` is what wrapped for the similar purpose I guess. So I'll let you think about whether you can do the same thing by adding all customize types into the range for the yaml deserializer to avoid `unsafe` keyword. I think for an API exposed to end user, it should never "unsafe" in terms of data/computer security, but the "unsafe" is left for developers to find out where in the source code that cause memory issue or potential security issue. 