### PR TITLE
specify sphinx configuration file expliitly

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,4 @@ python:
 sphinx:
     builder: html
     fail_on_warning: true
+    configuration: docs/source/conf.py


### PR DESCRIPTION
Follow https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/