### PR TITLE
Replace `nest_asyncio` with `greenlet` for nested process execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 keywords = ['workflow', 'multithreaded', 'rabbitmq']
 requires-python = '>=3.9'
 dependencies = [
+    'greenlet>=2.0.0',
     'kiwipy[rmq]~=0.9.0',
-    'nest_asyncio~=1.5,>=1.5.1',
     'pyyaml~=6.0',
 ]
 
@@ -131,8 +131,8 @@ check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
+    'greenlet.*',
     'kiwipy.*',
-    'nest_asyncio.*',
     'tblib.*',
 ]
 ignore_missing_imports = true

--- a/src/plumpy/__init__.py
+++ b/src/plumpy/__init__.py
@@ -8,7 +8,7 @@ from .communications import *
 from .events import *
 from .exceptions import *
 from .futures import *
-from .greenlet_bridge import run_until_complete
+from .greenlet_bridge import *
 from .loaders import *
 from .mixins import *
 from .persistence import *
@@ -35,7 +35,7 @@ __all__ = (
     + loaders.__all__
     + ports.__all__
     + process_states.__all__
-    + ['run_until_complete']
+    + greenlet_bridge.__all__
 )
 
 

--- a/src/plumpy/__init__.py
+++ b/src/plumpy/__init__.py
@@ -8,6 +8,7 @@ from .communications import *
 from .events import *
 from .exceptions import *
 from .futures import *
+from .greenlet_bridge import run_until_complete
 from .loaders import *
 from .mixins import *
 from .persistence import *
@@ -34,6 +35,7 @@ __all__ = (
     + loaders.__all__
     + ports.__all__
     + process_states.__all__
+    + ['run_until_complete']
 )
 
 

--- a/src/plumpy/events.py
+++ b/src/plumpy/events.py
@@ -10,7 +10,6 @@ __all__ = [
     'get_event_loop',
     'new_event_loop',
     'reset_event_loop_policy',
-    'run_until_complete',
     'set_event_loop',
     'set_event_loop_policy',
 ]
@@ -57,11 +56,6 @@ def set_event_loop_policy() -> None:
 def reset_event_loop_policy() -> None:
     """Reset the event loop policy to the default."""
     asyncio.set_event_loop_policy(None)
-
-
-def run_until_complete(future: asyncio.Future, loop: Optional[asyncio.AbstractEventLoop] = None) -> Any:
-    loop = loop or get_event_loop()
-    return loop.run_until_complete(future)
 
 
 class ProcessCallback:

--- a/src/plumpy/events.py
+++ b/src/plumpy/events.py
@@ -22,31 +22,32 @@ get_event_loop = asyncio.get_event_loop
 
 
 def set_event_loop(*args: Any, **kwargs: Any) -> None:
-    raise NotImplementedError('this method is not implemented because `plumpy` uses a single reentrant loop')
+    raise NotImplementedError('this method is not implemented because `plumpy` uses a single cached event loop')
 
 
 def new_event_loop(*args: Any, **kwargs: Any) -> asyncio.AbstractEventLoop:
-    raise NotImplementedError('this method is not implemented because `plumpy` uses a single reentrant loop')
+    raise NotImplementedError('this method is not implemented because `plumpy` uses a single cached event loop')
 
 
 class PlumpyEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
-    """Custom event policy that always returns the same event loop that is made reentrant by ``nest_asyncio``."""
+    """Custom event policy that always returns the same cached event loop.
+
+    Reentrancy for nested process execution is handled via greenlet bridging
+    in Process.execute() rather than by patching the event loop.
+    """
 
     _loop: Optional[asyncio.AbstractEventLoop] = None
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:
-        """Return the patched event loop."""
-        import nest_asyncio
-
+        """Return the cached event loop."""
         if self._loop is None:
             self._loop = super().get_event_loop()
-            nest_asyncio.apply(self._loop)
 
         return self._loop
 
 
 def set_event_loop_policy() -> None:
-    """Enable plumpy's event loop policy that will make event loop's reentrant."""
+    """Enable plumpy's event loop policy that caches a single event loop."""
     asyncio.set_event_loop_policy(PlumpyEventLoopPolicy())
     # Need to call the following explicitly for `asyncio.get_event_loop` to start calling the method of the new policy
     # in case an loop is already active.
@@ -55,13 +56,6 @@ def set_event_loop_policy() -> None:
 
 def reset_event_loop_policy() -> None:
     """Reset the event loop policy to the default."""
-    loop = get_event_loop()
-
-    cls = loop.__class__
-
-    del cls._check_running  # type: ignore
-    del cls._nest_patched  # type: ignore
-
     asyncio.set_event_loop_policy(None)
 
 

--- a/src/plumpy/greenlet_bridge.py
+++ b/src/plumpy/greenlet_bridge.py
@@ -7,6 +7,7 @@ while the event loop is running.
 """
 
 import asyncio
+import contextvars
 import sys
 import threading
 from contextvars import ContextVar
@@ -113,13 +114,22 @@ async def greenlet_spawn(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T
     result_holder: list = []
     exception_holder: list = []
 
+    # Capture the current context so we can propagate it into the worker
+    # greenlet. Greenlets start with a fresh empty context, so without this,
+    # ContextVars set by the caller (e.g. PROCESS_STACK) would not be visible.
+    ctx = contextvars.copy_context()
+
     def worker() -> None:
         """Worker greenlet that runs the sync function."""
-        _IN_WORKER_GREENLET.set(True)
-        try:
-            result_holder.append(fn(*args, **kwargs))
-        except BaseException as e:
-            exception_holder.append(e)
+
+        def _inner() -> None:
+            _IN_WORKER_GREENLET.set(True)
+            try:
+                result_holder.append(fn(*args, **kwargs))
+            except BaseException as e:
+                exception_holder.append(e)
+
+        ctx.run(_inner)
 
     worker_greenlet = greenlet(worker)
     switch_result = worker_greenlet.switch()

--- a/src/plumpy/greenlet_bridge.py
+++ b/src/plumpy/greenlet_bridge.py
@@ -173,6 +173,10 @@ def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]
         if in_worker_greenlet():
             return await_only(awaitable)
         else:
+            # Last resort: run in a separate thread with its own event loop.
+            # This assumes the awaitable is thread-safe. Process.execute() does
+            # NOT use this path — it raises instead — because process execution
+            # is generally not thread-safe (e.g. thread-local DB sessions).
             return run_in_thread(lambda: awaitable)
     else:
         return loop.run_until_complete(awaitable)

--- a/src/plumpy/greenlet_bridge.py
+++ b/src/plumpy/greenlet_bridge.py
@@ -14,7 +14,7 @@ from typing import Any, Awaitable, Callable, TypeVar
 
 from greenlet import getcurrent, greenlet
 
-__all__ = ['await_only', 'greenlet_spawn', 'in_worker_greenlet', 'run_in_thread']
+__all__ = ['await_only', 'greenlet_spawn', 'in_worker_greenlet', 'run_in_thread', 'run_until_complete']
 
 _T = TypeVar('_T')
 
@@ -140,3 +140,29 @@ async def greenlet_spawn(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T
         raise exception_holder[0]
 
     return result_holder[0] if result_holder else None  # type: ignore
+
+
+def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]) -> _T:
+    """Run an awaitable to completion, handling nested event loop scenarios.
+
+    This function provides backwards compatibility for code that previously
+    relied on nest_asyncio to allow nested run_until_complete() calls.
+
+    If the loop is not running, uses standard run_until_complete().
+    If the loop is running and we're in a worker greenlet, uses await_only().
+    If the loop is running but not in a greenlet, runs in a separate thread.
+
+    Args:
+        loop: The event loop to use.
+        awaitable: The awaitable to run.
+
+    Returns:
+        The result of the awaitable.
+    """
+    if loop.is_running():
+        if in_worker_greenlet():
+            return await_only(awaitable)
+        else:
+            return run_in_thread(lambda: awaitable)
+    else:
+        return loop.run_until_complete(awaitable)

--- a/src/plumpy/greenlet_bridge.py
+++ b/src/plumpy/greenlet_bridge.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""Greenlet-based async/sync bridge utilities for plumpy.
+
+This module provides utilities to bridge synchronous and asynchronous code
+using greenlets. It enables synchronous process code to await async operations
+while the event loop is running.
+"""
+
+import asyncio
+import sys
+import threading
+from contextvars import ContextVar
+from typing import Any, Awaitable, Callable, TypeVar
+
+from greenlet import getcurrent, greenlet
+
+__all__ = ['await_only', 'greenlet_spawn', 'in_worker_greenlet', 'run_in_thread']
+
+_T = TypeVar('_T')
+
+# Track if we're inside a worker greenlet
+_IN_WORKER_GREENLET: ContextVar[bool] = ContextVar('_in_worker_greenlet', default=False)
+
+
+def in_worker_greenlet() -> bool:
+    """Check if currently executing inside a worker greenlet.
+
+    Returns:
+        True if inside a worker greenlet (can use await_only to switch to parent),
+        False otherwise.
+    """
+    return _IN_WORKER_GREENLET.get()
+
+
+def run_in_thread(awaitable_factory: Callable[[], Awaitable[_T]]) -> _T:
+    """Run an awaitable in a separate thread with its own event loop.
+
+    This is used for nested process execution when the main event loop
+    is already running. The awaitable is created fresh in the thread
+    to avoid cross-loop issues.
+
+    Args:
+        awaitable_factory: A callable that creates the awaitable to run.
+
+    Returns:
+        The result of the awaitable.
+    """
+    result_holder: list = []
+    exception_holder: list = []
+
+    def thread_target() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            awaitable = awaitable_factory()
+            result_holder.append(loop.run_until_complete(awaitable))
+        except BaseException as e:
+            exception_holder.append(e)
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=thread_target)
+    thread.start()
+    thread.join()
+
+    if exception_holder:
+        raise exception_holder[0]
+
+    return result_holder[0] if result_holder else None  # type: ignore
+
+
+def await_only(awaitable: Awaitable[_T]) -> _T:
+    """Await an async operation from synchronous code inside a worker greenlet.
+
+    This function allows synchronous code to "await" an async operation by
+    switching to the parent greenlet which performs the actual await.
+
+    Must only be called from within a worker greenlet created by greenlet_spawn().
+
+    Args:
+        awaitable: The awaitable (coroutine, task, future) to await.
+
+    Returns:
+        The result of the awaited operation.
+
+    Raises:
+        RuntimeError: If called outside of a worker greenlet context.
+    """
+    if not _IN_WORKER_GREENLET.get():
+        raise RuntimeError(
+            'await_only() must be called from within a worker greenlet. '
+            'Use in_worker_greenlet() to check before calling.'
+        )
+
+    return getcurrent().parent.switch(awaitable)
+
+
+async def greenlet_spawn(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    """Run a sync function in a greenlet, allowing it to await via await_only().
+
+    This async function creates a greenlet to run a synchronous function.
+    The sync function can call await_only(some_awaitable) to perform async
+    operations while appearing to be synchronous code.
+
+    Args:
+        fn: The synchronous function to run.
+        *args: Positional arguments to pass to fn.
+        **kwargs: Keyword arguments to pass to fn.
+
+    Returns:
+        The return value of fn.
+    """
+    result_holder: list = []
+    exception_holder: list = []
+
+    def worker() -> None:
+        """Worker greenlet that runs the sync function."""
+        _IN_WORKER_GREENLET.set(True)
+        try:
+            result_holder.append(fn(*args, **kwargs))
+        except BaseException as e:
+            exception_holder.append(e)
+
+    worker_greenlet = greenlet(worker)
+    switch_result = worker_greenlet.switch()
+
+    # Process awaitable requests until worker completes
+    while not worker_greenlet.dead:
+        if isinstance(switch_result, Awaitable):
+            try:
+                value = await switch_result
+            except BaseException:
+                switch_result = worker_greenlet.throw(*sys.exc_info())
+            else:
+                switch_result = worker_greenlet.switch(value)
+        else:
+            break
+
+    if exception_holder:
+        raise exception_holder[0]
+
+    return result_holder[0] if result_holder else None  # type: ignore

--- a/src/plumpy/greenlet_bridge.py
+++ b/src/plumpy/greenlet_bridge.py
@@ -15,7 +15,7 @@ from typing import Any, Awaitable, Callable, TypeVar
 
 from greenlet import getcurrent, greenlet
 
-__all__ = ['await_only', 'greenlet_spawn', 'in_worker_greenlet', 'run_in_thread', 'run_until_complete']
+__all__ = ['in_worker_greenlet', 'run_in_greenlet', 'run_in_thread', 'run_until_complete', 'sync_await']
 
 _T = TypeVar('_T')
 
@@ -27,7 +27,7 @@ def in_worker_greenlet() -> bool:
     """Check if currently executing inside a worker greenlet.
 
     Returns:
-        True if inside a worker greenlet (can use await_only to switch to parent),
+        True if inside a worker greenlet (can use sync_await to switch to parent),
         False otherwise.
     """
     return _IN_WORKER_GREENLET.get()
@@ -70,13 +70,13 @@ def run_in_thread(awaitable_factory: Callable[[], Awaitable[_T]]) -> _T:
     return result_holder[0] if result_holder else None  # type: ignore
 
 
-def await_only(awaitable: Awaitable[_T]) -> _T:
+def sync_await(awaitable: Awaitable[_T]) -> _T:
     """Await an async operation from synchronous code inside a worker greenlet.
 
     This function allows synchronous code to "await" an async operation by
     switching to the parent greenlet which performs the actual await.
 
-    Must only be called from within a worker greenlet created by greenlet_spawn().
+    Must only be called from within a worker greenlet created by run_in_greenlet().
 
     Args:
         awaitable: The awaitable (coroutine, task, future) to await.
@@ -89,18 +89,18 @@ def await_only(awaitable: Awaitable[_T]) -> _T:
     """
     if not _IN_WORKER_GREENLET.get():
         raise RuntimeError(
-            'await_only() must be called from within a worker greenlet. '
+            'sync_await() must be called from within a worker greenlet. '
             'Use in_worker_greenlet() to check before calling.'
         )
 
     return getcurrent().parent.switch(awaitable)
 
 
-async def greenlet_spawn(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
-    """Run a sync function in a greenlet, allowing it to await via await_only().
+async def run_in_greenlet(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    """Run a sync function in a greenlet, allowing it to await via sync_await().
 
     This async function creates a greenlet to run a synchronous function.
-    The sync function can call await_only(some_awaitable) to perform async
+    The sync function can call sync_await(some_awaitable) to perform async
     operations while appearing to be synchronous code.
 
     Args:
@@ -159,7 +159,7 @@ def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]
     relied on nest_asyncio to allow nested run_until_complete() calls.
 
     If the loop is not running, uses standard run_until_complete().
-    If the loop is running and we're in a worker greenlet, uses await_only().
+    If the loop is running and we're in a worker greenlet, uses sync_await().
     If the loop is running but not in a greenlet, runs in a separate thread.
 
     Args:
@@ -171,7 +171,7 @@ def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]
     """
     if loop.is_running():
         if in_worker_greenlet():
-            return await_only(awaitable)
+            return sync_await(awaitable)
         else:
             # Last resort: run in a separate thread with its own event loop.
             # This assumes the awaitable is thread-safe. Process.execute() does

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -1319,9 +1319,13 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         if loop.is_running():
             # Nested execution: loop already running
             if in_worker_greenlet():
-                # We're in a worker greenlet - can use await_only
                 await_only(self.step_until_terminated())
             else:
+                # Unlike run_until_complete() which falls back to run_in_thread(),
+                # we raise here because Process execution is not thread-safe:
+                # consumers like AiiDA use thread-local scoped sessions (SQLAlchemy),
+                # so running in a separate thread would use a different DB session
+                # that knows nothing about the objects created on the main thread.
                 raise RuntimeError(
                     'Cannot synchronously execute a process while the event loop is running outside a worker '
                     'greenlet. Run the process from async code (e.g. `await process.step_until_terminated()`) or '

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -14,7 +14,6 @@ import time
 import uuid
 import warnings
 from contextvars import ContextVar
-from functools import partial
 from types import TracebackType
 from typing import (
     Any,
@@ -51,7 +50,7 @@ from .base import state_machine
 from .base.state_machine import StateEntryFailed, StateMachine, TransitionFailed, event
 from .base.utils import call_with_super_check, super_check
 from .event_helper import EventHelper
-from .greenlet_bridge import await_only, greenlet_spawn, in_worker_greenlet, run_in_thread
+from .greenlet_bridge import await_only, greenlet_spawn, in_worker_greenlet
 from .process_comms import FORCE_KILL_KEY, MESSAGE_TEXT_KEY, MessageBuilder, MessageType
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -914,6 +913,9 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
     def on_terminated(self) -> None:
         """Call when a terminal state is reached."""
+        if self._paused is not None and not self._paused.done():
+            self._paused.set_result(True)
+            self._paused = None
         super().on_terminated()
         self.close()
 
@@ -1320,8 +1322,11 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
                 # We're in a worker greenlet - can use await_only
                 await_only(self.step_until_terminated())
             else:
-                # Called from async context - run in separate thread
-                self._execute_in_thread()
+                raise RuntimeError(
+                    'Cannot synchronously execute a process while the event loop is running outside a worker '
+                    'greenlet. Run the process from async code (e.g. `await process.step_until_terminated()`) or '
+                    'wrap the synchronous call with `greenlet_spawn()`.'
+                )
         else:
             # Top-level execution: wrap in greenlet_spawn for nested support
             loop.run_until_complete(greenlet_spawn(self._execute_sync))
@@ -1332,23 +1337,6 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         """Synchronous execution helper that runs inside greenlet context."""
         if not self.has_terminated():
             await_only(self.step_until_terminated())
-
-    def _execute_in_thread(self) -> None:
-        """Execute the process in a separate thread with its own event loop.
-
-        This is used for nested process execution when the main event loop
-        is already running and we're not in a greenlet context.
-        """
-
-        run_in_thread(partial(self._step_with_loop_swap, self._loop))
-
-    async def _step_with_loop_swap(self, old_loop: asyncio.AbstractEventLoop) -> None:
-        """Step until terminated, temporarily swapping to the current thread's event loop."""
-        self._loop = asyncio.get_event_loop()
-        try:
-            await self.step_until_terminated()
-        finally:
-            self._loop = old_loop
 
     @ensure_not_closed
     async def step(self) -> None:
@@ -1364,6 +1352,8 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         if self.paused and self._paused is not None:
             await self._paused
+            if self.has_terminated():
+                return
 
         try:
             self._stepping = True

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -1020,9 +1020,11 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         kiwi_future = kiwipy.Future()
 
         async def run_callback() -> None:
+            from .greenlet_bridge import greenlet_spawn
+
             with kiwipy.capture_exceptions(kiwi_future):
                 try:
-                    result = callback(*args, **kwargs)
+                    result = await greenlet_spawn(callback, *args, **kwargs)
                 except Exception as exc:
                     import inspect
                     import traceback

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -50,7 +50,7 @@ from .base import state_machine
 from .base.state_machine import StateEntryFailed, StateMachine, TransitionFailed, event
 from .base.utils import call_with_super_check, super_check
 from .event_helper import EventHelper
-from .greenlet_bridge import await_only, greenlet_spawn, in_worker_greenlet
+from .greenlet_bridge import in_worker_greenlet, run_in_greenlet, sync_await
 from .process_comms import FORCE_KILL_KEY, MESSAGE_TEXT_KEY, MessageBuilder, MessageType
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -1022,11 +1022,11 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         kiwi_future = kiwipy.Future()
 
         async def run_callback() -> None:
-            from .greenlet_bridge import greenlet_spawn
+            from .greenlet_bridge import run_in_greenlet
 
             with kiwipy.capture_exceptions(kiwi_future):
                 try:
-                    result = await greenlet_spawn(callback, *args, **kwargs)
+                    result = await run_in_greenlet(callback, *args, **kwargs)
                 except Exception as exc:
                     import inspect
                     import traceback
@@ -1319,28 +1319,28 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         if loop.is_running():
             # Nested execution: loop already running
             if in_worker_greenlet():
-                await_only(self.step_until_terminated())
+                sync_await(self.step_until_terminated())
             else:
                 # Unlike run_until_complete() which falls back to run_in_thread(),
                 # we raise here because Process execution is not thread-safe:
-                # consumers like AiiDA use thread-local scoped sessions (SQLAlchemy),
+                # consumers like AiiDA use thread-local scoped sessions,
                 # so running in a separate thread would use a different DB session
                 # that knows nothing about the objects created on the main thread.
                 raise RuntimeError(
                     'Cannot synchronously execute a process while the event loop is running outside a worker '
                     'greenlet. Run the process from async code (e.g. `await process.step_until_terminated()`) or '
-                    'wrap the synchronous call with `greenlet_spawn()`.'
+                    'wrap the synchronous call with `run_in_greenlet()`.'
                 )
         else:
-            # Top-level execution: wrap in greenlet_spawn for nested support
-            loop.run_until_complete(greenlet_spawn(self._execute_sync))
+            # Top-level execution: wrap in run_in_greenlet for nested support
+            loop.run_until_complete(run_in_greenlet(self._execute_sync))
 
         return self.future().result()
 
     def _execute_sync(self) -> None:
         """Synchronous execution helper that runs inside greenlet context."""
         if not self.has_terminated():
-            await_only(self.step_until_terminated())
+            sync_await(self.step_until_terminated())
 
     @ensure_not_closed
     async def step(self) -> None:

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -14,6 +14,7 @@ import time
 import uuid
 import warnings
 from contextvars import ContextVar
+from functools import partial
 from types import TracebackType
 from typing import (
     Any,
@@ -50,6 +51,7 @@ from .base import state_machine
 from .base.state_machine import StateEntryFailed, StateMachine, TransitionFailed, event
 from .base.utils import call_with_super_check, super_check
 from .event_helper import EventHelper
+from .greenlet_bridge import await_only, greenlet_spawn, in_worker_greenlet, run_in_thread
 from .process_comms import FORCE_KILL_KEY, MESSAGE_TEXT_KEY, MessageBuilder, MessageType
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -1298,15 +1300,53 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
     @ensure_not_closed
     def execute(self) -> Optional[Dict[str, Any]]:
-        """
-        Execute the process.  This will return if the process terminates or is paused.
+        """Execute the process synchronously.
+
+        If called while the event loop is running (nested execution),
+        uses greenlet bridging to yield to the async context.
 
         :return: None if not terminated, otherwise `self.outputs`
         """
-        if not self.has_terminated():
-            self.loop.run_until_complete(self.step_until_terminated())
+        if self.has_terminated():
+            return self.future().result()
+
+        loop = self.loop
+
+        if loop.is_running():
+            # Nested execution: loop already running
+            if in_worker_greenlet():
+                # We're in a worker greenlet - can use await_only
+                await_only(self.step_until_terminated())
+            else:
+                # Called from async context - run in separate thread
+                self._execute_in_thread()
+        else:
+            # Top-level execution: wrap in greenlet_spawn for nested support
+            loop.run_until_complete(greenlet_spawn(self._execute_sync))
 
         return self.future().result()
+
+    def _execute_sync(self) -> None:
+        """Synchronous execution helper that runs inside greenlet context."""
+        if not self.has_terminated():
+            await_only(self.step_until_terminated())
+
+    def _execute_in_thread(self) -> None:
+        """Execute the process in a separate thread with its own event loop.
+
+        This is used for nested process execution when the main event loop
+        is already running and we're not in a greenlet context.
+        """
+
+        run_in_thread(partial(self._step_with_loop_swap, self._loop))
+
+    async def _step_with_loop_swap(self, old_loop: asyncio.AbstractEventLoop) -> None:
+        """Step until terminated, temporarily swapping to the current thread's event loop."""
+        self._loop = asyncio.get_event_loop()
+        try:
+            await self.step_until_terminated()
+        finally:
+            self._loop = old_loop
 
     @ensure_not_closed
     async def step(self) -> None:

--- a/src/plumpy/utils.py
+++ b/src/plumpy/utils.py
@@ -205,9 +205,11 @@ def ensure_coroutine(coro_or_fn: Any) -> Callable[..., Awaitable[Any]]:
         if inspect.isclass(coro_or_fn):
             coro_or_fn = coro_or_fn.__call__
 
+        from .greenlet_bridge import greenlet_spawn
+
         @functools.wraps(coro_or_fn)
         async def wrap(*args: Any, **kwargs: Any) -> Callable[..., Any]:
-            return coro_or_fn(*args, **kwargs)
+            return await greenlet_spawn(coro_or_fn, *args, **kwargs)
 
         return wrap
 

--- a/src/plumpy/utils.py
+++ b/src/plumpy/utils.py
@@ -205,11 +205,11 @@ def ensure_coroutine(coro_or_fn: Any) -> Callable[..., Awaitable[Any]]:
         if inspect.isclass(coro_or_fn):
             coro_or_fn = coro_or_fn.__call__
 
-        from .greenlet_bridge import greenlet_spawn
+        from .greenlet_bridge import run_in_greenlet
 
         @functools.wraps(coro_or_fn)
         async def wrap(*args: Any, **kwargs: Any) -> Callable[..., Any]:
-            return await greenlet_spawn(coro_or_fn, *args, **kwargs)
+            return await run_in_greenlet(coro_or_fn, *args, **kwargs)
 
         return wrap
 

--- a/tests/notebooks/get_event_loop.ipynb
+++ b/tests/notebooks/get_event_loop.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "set_event_loop_policy()\n",
     "assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)\n",
-    "assert hasattr(asyncio.get_event_loop(), '_nest_patched')"
+    "assert asyncio.get_event_loop() is asyncio.get_event_loop()"
    ]
   }
  ],
@@ -32,7 +32,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,7 +29,6 @@ def test_get_event_loop():
     set_event_loop_policy()
     assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
     assert asyncio.get_event_loop() is asyncio.get_event_loop()
-    assert asyncio.get_event_loop()._nest_patched is not None
 
 
 def test_set_event_loop():

--- a/uv.lock
+++ b/uv.lock
@@ -1657,8 +1657,8 @@ wheels = [
 name = "plumpy"
 source = { editable = "." }
 dependencies = [
+    { name = "greenlet" },
     { name = "kiwipy", extra = ["rmq"] },
-    { name = "nest-asyncio" },
     { name = "pyyaml" },
 ]
 
@@ -1694,6 +1694,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "greenlet", specifier = ">=2.0.0" },
     { name = "importlib-metadata", marker = "extra == 'docs'", specifier = "~=4.12.0" },
     { name = "importlib-resources", marker = "extra == 'tests'", specifier = "~=5.2" },
     { name = "ipykernel", marker = "extra == 'tests'", specifier = "==6.12.1" },
@@ -1703,7 +1704,6 @@ requires-dist = [
     { name = "markupsafe", marker = "extra == 'docs'", specifier = "==2.0.1" },
     { name = "mypy", marker = "extra == 'pre-commit'", specifier = "==1.18.2" },
     { name = "myst-nb", marker = "extra == 'docs'", specifier = "~=1.2.0" },
-    { name = "nest-asyncio", specifier = "~=1.5,>=1.5.1" },
     { name = "pre-commit", marker = "extra == 'pre-commit'", specifier = "~=3.6" },
     { name = "pytest", marker = "extra == 'tests'", specifier = "~=8.4" },
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = "~=0.12,<0.17" },


### PR DESCRIPTION
### A bit of history 
`nest_asyncio` monkey-patches asyncio internals to allow re-entrant run_until_complete() calls. Although convenient, this is inherently fragile and made debugging in some cases almost impossible. Moreover a lot of packages which were using `nest_asyncio` historically, moved to `greenlet` after the author have passed [which is deeply sad] for maintainability reasons.

This PR give synchronous code a clean, explicit way to call async operations.

### Why did we need `nest_asyncio` in the first place?

The problem that `nest_asyncio` was solving for us is to allow async calls occur in a sync function. 
Note that plumpy's Process model is fundamentally synchronous, that means process steps, calcfunctions, and workfunctions. But aiida engine that drives it (the state machine, the daemon, the runner) is async. Whenever synchronous process code needs to do something async (like running a nested process, cancelling a scheduler job, or performing a transport operation), it historically called `loop.run_until_complete()`. That doesn't work when the loop is already running (which it is inside the daemon, inside Jupyter, etc.), so `nest_asyncio` was used to make the loop re-entrant.

### The replacement

The idea is instead of letting sync code call `run_until_complete()` on a running loop (which requires patching), we run the sync code inside a special "worker greenlet." When that code needs an async result, it cooperatively switches to a parent greenlet that lives in an async context, hands it the awaitable, the parent does the real `await`, then switches back with the result. From the sync code's perspective, the call looks blocking. From the event loop's perspective, nothing unusual happened — it just awaited a coroutine.