### PR TITLE
Replace nest_asyncio with greenback for nested process execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 keywords = ['workflow', 'multithreaded', 'rabbitmq']
 requires-python = '>=3.9'
 dependencies = [
-    'greenback>=1.0',
+    'greenback~=1.0',
     'kiwipy[rmq]~=0.9.0',
     'pyyaml~=6.0',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 keywords = ['workflow', 'multithreaded', 'rabbitmq']
 requires-python = '>=3.9'
 dependencies = [
+    'greenback>=1.0',
     'kiwipy[rmq]~=0.9.0',
-    'nest_asyncio~=1.5,>=1.5.1',
     'pyyaml~=6.0',
 ]
 
@@ -131,8 +131,8 @@ check_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = [
+    'greenback.*',
     'kiwipy.*',
-    'nest_asyncio.*',
     'tblib.*',
 ]
 ignore_missing_imports = true

--- a/src/plumpy/__init__.py
+++ b/src/plumpy/__init__.py
@@ -8,6 +8,7 @@ from .communications import *
 from .events import *
 from .exceptions import *
 from .futures import *
+from .greenback_bridge import *
 from .loaders import *
 from .mixins import *
 from .persistence import *
@@ -34,6 +35,7 @@ __all__ = (
     + loaders.__all__
     + ports.__all__
     + process_states.__all__
+    + greenback_bridge.__all__
 )
 
 

--- a/src/plumpy/events.py
+++ b/src/plumpy/events.py
@@ -10,7 +10,6 @@ __all__ = [
     'get_event_loop',
     'new_event_loop',
     'reset_event_loop_policy',
-    'run_until_complete',
     'set_event_loop',
     'set_event_loop_policy',
 ]
@@ -22,31 +21,33 @@ get_event_loop = asyncio.get_event_loop
 
 
 def set_event_loop(*args: Any, **kwargs: Any) -> None:
-    raise NotImplementedError('this method is not implemented because `plumpy` uses a single reentrant loop')
+    raise NotImplementedError('this method is not implemented because `plumpy` uses a single cached event loop')
 
 
 def new_event_loop(*args: Any, **kwargs: Any) -> asyncio.AbstractEventLoop:
-    raise NotImplementedError('this method is not implemented because `plumpy` uses a single reentrant loop')
+    raise NotImplementedError('this method is not implemented because `plumpy` uses a single cached event loop')
 
 
 class PlumpyEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
-    """Custom event policy that always returns the same event loop that is made reentrant by ``nest_asyncio``."""
+    """Custom event policy that always returns the same cached event loop.
+
+    Reentrancy for nested process execution is handled via greenback bridging
+    in Process.execute() rather than by patching the event loop.
+    """
 
     _loop: Optional[asyncio.AbstractEventLoop] = None
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:
-        """Return the patched event loop."""
-        import nest_asyncio
-
+        """Return the cached event loop."""
         if self._loop is None:
-            self._loop = super().get_event_loop()
-            nest_asyncio.apply(self._loop)
+            self._loop = self.new_event_loop()
+            self.set_event_loop(self._loop)
 
         return self._loop
 
 
 def set_event_loop_policy() -> None:
-    """Enable plumpy's event loop policy that will make event loop's reentrant."""
+    """Enable plumpy's event loop policy that caches a single event loop."""
     asyncio.set_event_loop_policy(PlumpyEventLoopPolicy())
     # Need to call the following explicitly for `asyncio.get_event_loop` to start calling the method of the new policy
     # in case an loop is already active.
@@ -55,19 +56,7 @@ def set_event_loop_policy() -> None:
 
 def reset_event_loop_policy() -> None:
     """Reset the event loop policy to the default."""
-    loop = get_event_loop()
-
-    cls = loop.__class__
-
-    del cls._check_running  # type: ignore
-    del cls._nest_patched  # type: ignore
-
     asyncio.set_event_loop_policy(None)
-
-
-def run_until_complete(future: asyncio.Future, loop: Optional[asyncio.AbstractEventLoop] = None) -> Any:
-    loop = loop or get_event_loop()
-    return loop.run_until_complete(future)
 
 
 class ProcessCallback:

--- a/src/plumpy/greenback_bridge.py
+++ b/src/plumpy/greenback_bridge.py
@@ -52,4 +52,9 @@ def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]
             'is available. If running in a Jupyter notebook, call load_profile() '
             'in a prior cell.'
         )
-    return loop.run_until_complete(awaitable)
+
+    async def _with_portal() -> _T:
+        await greenback.ensure_portal()
+        return await awaitable
+
+    return loop.run_until_complete(_with_portal())

--- a/src/plumpy/greenback_bridge.py
+++ b/src/plumpy/greenback_bridge.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Async/sync bridge for plumpy, built on greenback.
+
+This module is the sole interface to greenback within the plumpy/aiida ecosystem.
+All greenback usage should go through these wrappers so that the underlying
+library remains an implementation detail of plumpy.
+"""
+
+import asyncio
+from typing import Any, Awaitable, Callable, TypeVar
+
+import greenback
+
+__all__ = [
+    'ensure_portal',
+    'has_portal',
+    'run_until_complete',
+    'run_with_portal',
+    'sync_await',
+]
+
+_T = TypeVar('_T')
+
+
+def has_portal() -> bool:
+    """Return True if ``sync_await()`` can be called in the current context."""
+    return greenback.has_portal()
+
+
+def sync_await(awaitable: Awaitable[_T]) -> _T:
+    """Await *awaitable* from synchronous code. Requires an active portal."""
+    return greenback.await_(awaitable)
+
+
+async def run_with_portal(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    """Run sync *fn* in a greenback portal so it can call ``sync_await()``."""
+    return await greenback.with_portal_run_sync(fn, *args, **kwargs)
+
+
+async def ensure_portal() -> None:
+    """Ensure a greenback portal is active on the current asyncio task (no-op if one exists)."""
+    await greenback.ensure_portal()
+
+
+def run_until_complete(loop: asyncio.AbstractEventLoop, awaitable: Awaitable[_T]) -> _T:
+    """Run *awaitable* to completion, even if the event loop is already running."""
+    if loop.is_running():
+        if greenback.has_portal():
+            return greenback.await_(awaitable)
+        raise RuntimeError(
+            'Cannot run awaitable: event loop is running but no greenback portal '
+            'is available. If running in a Jupyter notebook, call load_profile() '
+            'in a prior cell.'
+        )
+    return loop.run_until_complete(awaitable)

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -50,7 +50,7 @@ from .base import state_machine
 from .base.state_machine import StateEntryFailed, StateMachine, TransitionFailed, event
 from .base.utils import call_with_super_check, super_check
 from .event_helper import EventHelper
-from .greenback_bridge import has_portal, run_with_portal, sync_await
+from .greenback_bridge import run_until_complete, run_with_portal
 from .process_comms import FORCE_KILL_KEY, MESSAGE_TEXT_KEY, MessageBuilder, MessageType
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -1019,7 +1019,6 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         kiwi_future = kiwipy.Future()
 
         async def run_callback() -> None:
-            from .greenback_bridge import run_with_portal
 
             with kiwipy.capture_exceptions(kiwi_future):
                 try:
@@ -1308,28 +1307,9 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         if self.has_terminated():
             return self.future().result()
 
-        loop = self.loop
-
-        if loop.is_running():
-            if has_portal():
-                sync_await(self.step_until_terminated())
-            else:
-                # There is no other way to support this path of execution, unless we spwan a thread.
-                # Which we did our best to avoid that, since some operation might not be thread-safe
-                raise RuntimeError(
-                    'Cannot synchronously execute a process while the event loop is running '
-                    'and no greenback portal is available. If running in a Jupyter notebook, '
-                    'call load_profile() in a prior cell.'
-                )
-        else:
-            loop.run_until_complete(run_with_portal(self._execute_sync))
+        run_until_complete(self.loop, self.step_until_terminated())
 
         return self.future().result()
-
-    def _execute_sync(self) -> None:
-        """Synchronous execution helper that runs inside greenback portal."""
-        if not self.has_terminated():
-            sync_await(self.step_until_terminated())
 
     @ensure_not_closed
     async def step(self) -> None:

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -1019,7 +1019,6 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         kiwi_future = kiwipy.Future()
 
         async def run_callback() -> None:
-
             with kiwipy.capture_exceptions(kiwi_future):
                 try:
                     result = await run_with_portal(callback, *args, **kwargs)

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -50,6 +50,7 @@ from .base import state_machine
 from .base.state_machine import StateEntryFailed, StateMachine, TransitionFailed, event
 from .base.utils import call_with_super_check, super_check
 from .event_helper import EventHelper
+from .greenback_bridge import has_portal, run_with_portal, sync_await
 from .process_comms import FORCE_KILL_KEY, MESSAGE_TEXT_KEY, MessageBuilder, MessageType
 from .process_listener import ProcessListener
 from .process_spec import ProcessSpec
@@ -912,6 +913,9 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
     def on_terminated(self) -> None:
         """Call when a terminal state is reached."""
+        if self._paused is not None and not self._paused.done():
+            self._paused.set_result(True)
+            self._paused = None
         super().on_terminated()
         self.close()
 
@@ -1018,9 +1022,11 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
         kiwi_future = kiwipy.Future()
 
         async def run_callback() -> None:
+            from .greenback_bridge import run_with_portal
+
             with kiwipy.capture_exceptions(kiwi_future):
                 try:
-                    result = callback(*args, **kwargs)
+                    result = await run_with_portal(callback, *args, **kwargs)
                 except Exception as exc:
                     import inspect
                     import traceback
@@ -1298,15 +1304,35 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
     @ensure_not_closed
     def execute(self) -> Optional[Dict[str, Any]]:
-        """
-        Execute the process.  This will return if the process terminates or is paused.
+        """Execute the process synchronously.
 
         :return: None if not terminated, otherwise `self.outputs`
         """
-        if not self.has_terminated():
-            self.loop.run_until_complete(self.step_until_terminated())
+        if self.has_terminated():
+            return self.future().result()
+
+        loop = self.loop
+
+        if loop.is_running():
+            if has_portal():
+                sync_await(self.step_until_terminated())
+            else:
+                # There is no other way to support this path of execution, unless we spwan a thread.
+                # Which we did our best to avoid that, since some operation might not be thread-safe
+                raise RuntimeError(
+                    'Cannot synchronously execute a process while the event loop is running '
+                    'and no greenback portal is available. If running in a Jupyter notebook, '
+                    'call load_profile() in a prior cell.'
+                )
+        else:
+            loop.run_until_complete(run_with_portal(self._execute_sync))
 
         return self.future().result()
+
+    def _execute_sync(self) -> None:
+        """Synchronous execution helper that runs inside greenback portal."""
+        if not self.has_terminated():
+            sync_await(self.step_until_terminated())
 
     @ensure_not_closed
     async def step(self) -> None:
@@ -1322,6 +1348,8 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         if self.paused and self._paused is not None:
             await self._paused
+            if self.has_terminated():
+                return
 
         try:
             self._stepping = True

--- a/src/plumpy/processes.py
+++ b/src/plumpy/processes.py
@@ -913,9 +913,6 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
     def on_terminated(self) -> None:
         """Call when a terminal state is reached."""
-        if self._paused is not None and not self._paused.done():
-            self._paused.set_result(True)
-            self._paused = None
         super().on_terminated()
         self.close()
 
@@ -1348,8 +1345,6 @@ class Process(StateMachine, persistence.Savable, metaclass=ProcessStateMachineMe
 
         if self.paused and self._paused is not None:
             await self._paused
-            if self.has_terminated():
-                return
 
         try:
             self._stepping = True

--- a/src/plumpy/utils.py
+++ b/src/plumpy/utils.py
@@ -205,9 +205,11 @@ def ensure_coroutine(coro_or_fn: Any) -> Callable[..., Awaitable[Any]]:
         if inspect.isclass(coro_or_fn):
             coro_or_fn = coro_or_fn.__call__
 
+        from .greenback_bridge import run_with_portal
+
         @functools.wraps(coro_or_fn)
         async def wrap(*args: Any, **kwargs: Any) -> Callable[..., Any]:
-            return coro_or_fn(*args, **kwargs)
+            return await run_with_portal(coro_or_fn, *args, **kwargs)
 
         return wrap
 

--- a/tests/notebooks/get_event_loop.ipynb
+++ b/tests/notebooks/get_event_loop.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "set_event_loop_policy()\n",
     "assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)\n",
-    "assert hasattr(asyncio.get_event_loop(), '_nest_patched')"
+    "assert asyncio.get_event_loop() is asyncio.get_event_loop()"
    ]
   }
  ],

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,7 +29,6 @@ def test_get_event_loop():
     set_event_loop_policy()
     assert isinstance(asyncio.get_event_loop_policy(), PlumpyEventLoopPolicy)
     assert asyncio.get_event_loop() is asyncio.get_event_loop()
-    assert asyncio.get_event_loop()._nest_patched is not None
 
 
 def test_set_event_loop():

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -238,6 +238,20 @@ class TestProcess(unittest.TestCase):
         self.assertEqual(proc.state, ProcessState.FINISHED)
         self.assertEqual(proc.outputs, {'default': 5})
 
+    def test_execute_no_portal_raises(self):
+        """Calling execute() while the loop is running without a portal raises RuntimeError."""
+        loop = asyncio.new_event_loop()
+
+        async def _test():
+            proc = utils.DummyProcess()
+            with self.assertRaisesRegex(RuntimeError, 'no greenback portal'):
+                proc.execute()
+
+        try:
+            loop.run_until_complete(_test())
+        finally:
+            loop.close()
+
     def test_run_from_class(self):
         # Test running through class method
         proc = utils.DummyProcessWithOutput()

--- a/uv.lock
+++ b/uv.lock
@@ -591,6 +591,20 @@ wheels = [
 ]
 
 [[package]]
+name = "greenback"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "outcome" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/d2/3b70d0f03a1e0f48d4f2348de435fa282e5530ae60812fef672cabc40a28/greenback-1.3.0.tar.gz", hash = "sha256:d1441f542ec9c6efb32a9250dd954a5b1cc1eb789294c19b1eb747f49cab818c", size = 8070613, upload-time = "2025-12-23T01:49:33.582Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/41/a1b338d80775c47f79cd7310d57ad4b98730f0656b15464a57dab821c5bb/greenback-1.3.0-py3-none-any.whl", hash = "sha256:b0a333a35b40f422981ebdeefc7e0a00568f2ac634604d0108cc8c30da9b6252", size = 29079, upload-time = "2025-12-23T01:49:31.81Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1548,6 +1562,18 @@ wheels = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1657,8 +1683,8 @@ wheels = [
 name = "plumpy"
 source = { editable = "." }
 dependencies = [
+    { name = "greenback" },
     { name = "kiwipy", extra = ["rmq"] },
-    { name = "nest-asyncio" },
     { name = "pyyaml" },
 ]
 
@@ -1694,6 +1720,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "greenback", specifier = ">=1.0" },
     { name = "importlib-metadata", marker = "extra == 'docs'", specifier = "~=4.12.0" },
     { name = "importlib-resources", marker = "extra == 'tests'", specifier = "~=5.2" },
     { name = "ipykernel", marker = "extra == 'tests'", specifier = "==6.12.1" },
@@ -1703,7 +1730,6 @@ requires-dist = [
     { name = "markupsafe", marker = "extra == 'docs'", specifier = "==2.0.1" },
     { name = "mypy", marker = "extra == 'pre-commit'", specifier = "==1.18.2" },
     { name = "myst-nb", marker = "extra == 'docs'", specifier = "~=1.2.0" },
-    { name = "nest-asyncio", specifier = "~=1.5,>=1.5.1" },
     { name = "pre-commit", marker = "extra == 'pre-commit'", specifier = "~=3.6" },
     { name = "pytest", marker = "extra == 'tests'", specifier = "~=8.4" },
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = "~=0.12,<0.17" },


### PR DESCRIPTION
### A bit of history 
`nest_asyncio` monkey-patches asyncio internals to allow re-entrant run_until_complete() calls. Although convenient, this is inherently fragile and made debugging in some cases almost impossible. Moreover a lot of packages which were using `nest_asyncio` historically, moved to `greenlet` after the author have passed [which is deeply sad] for maintainability reasons.

This PR give synchronous code a clean, explicit way to call async operations.

### Why did we need `nest_asyncio` in the first place?

The problem that `nest_asyncio` was solving for us is to allow async calls occur in a sync function. 
Note that plumpy's Process model is fundamentally synchronous, that means process steps, calcfunctions, and workfunctions. But aiida engine that drives it (the state machine, the daemon, the runner) is async. Whenever synchronous process code needs to do something async (like running a nested process, cancelling a scheduler job, or performing a transport operation), it historically called `loop.run_until_complete()`. That doesn't work when the loop is already running (which it is inside the daemon, inside Jupyter, etc.), so `nest_asyncio` was used to make the loop re-entrant.

### The replacement
greenback as the sole mechanism for running async code from synchronous contexts, removing the dependency on nest_asyncio and its event-loop patching. Process.execute() now delegates to a unified run_until_complete() bridge that handles both running and idle loops.

### Design choices
We decided instead of directly calling on greenback use a wrapper bridge. This way aiida-core will not need to directly list greenback as dependencies. Reducing the incompatibilities between packages. If any fixes required regarding versions, incompatibilities, etc, it won't need to be fixed in both packages. Also this way we have a very clear bridge definition, if we ever wanted to replace greenback, we know exactly what we need. 

The execute definition is now a lot more clear than before. Its re-entrancy is guaranteed with our own implementation of run_until_complete